### PR TITLE
NTS: Cycle 17 updates and new chart versions.

### DIFF
--- a/apps/ataos/requirements.yaml
+++ b/apps/ataos/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: csc
-  version: 0.6.1
+  version: 0.7.1
   repository: https://lsst-ts.github.io/charts/

--- a/apps/ataos/values-ncsa-teststand.yaml
+++ b/apps/ataos/values-ncsa-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/ataos
-    tag: c0016
+    tag: c0017
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/atdome/requirements.yaml
+++ b/apps/atdome/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: csc
-  version: 0.6.1
+  version: 0.7.1
   repository: https://lsst-ts.github.io/charts/

--- a/apps/atdome/values-ncsa-teststand.yaml
+++ b/apps/atdome/values-ncsa-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/atdome
-    tag: c0016
+    tag: c0017
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/atdometrajectory/requirements.yaml
+++ b/apps/atdometrajectory/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: csc
-  version: 0.6.1
+  version: 0.7.1
   repository: https://lsst-ts.github.io/charts/

--- a/apps/atdometrajectory/values-ncsa-teststand.yaml
+++ b/apps/atdometrajectory/values-ncsa-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/atdometrajectory
-    tag: c0016
+    tag: c0017
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/atheaderservice/requirements.yaml
+++ b/apps/atheaderservice/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: csc
-  version: 0.6.2
+  version: 0.7.1
   repository: https://lsst-ts.github.io/charts/

--- a/apps/athexapod/requirements.yaml
+++ b/apps/athexapod/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: csc
-  version: 0.6.1
+  version: 0.7.1
   repository: https://lsst-ts.github.io/charts/

--- a/apps/athexapod/values-ncsa-teststand.yaml
+++ b/apps/athexapod/values-ncsa-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/athexapod
-    tag: c0016
+    tag: c0017
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/atmcs/requirements.yaml
+++ b/apps/atmcs/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: csc
-  version: 0.6.1
+  version: 0.7.1
   repository: https://lsst-ts.github.io/charts/

--- a/apps/atmcs/values-ncsa-teststand.yaml
+++ b/apps/atmcs/values-ncsa-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/atmcs_sim
-    tag: c0016
+    tag: c0017
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/atpneumatics/requirements.yaml
+++ b/apps/atpneumatics/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: csc
-  version: 0.6.1
+  version: 0.7.1
   repository: https://lsst-ts.github.io/charts/

--- a/apps/atpneumatics/values-ncsa-teststand.yaml
+++ b/apps/atpneumatics/values-ncsa-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/at_pneumatics_sim
-    tag: c0016
+    tag: c0017
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/atptg/requirements.yaml
+++ b/apps/atptg/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: csc
-  version: 0.6.1
+  version: 0.7.1
   repository: https://lsst-ts.github.io/charts/

--- a/apps/atptg/values-ncsa-teststand.yaml
+++ b/apps/atptg/values-ncsa-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/ptkernel
-    tag: c0016
+    tag: c0017
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/atqueue/requirements.yaml
+++ b/apps/atqueue/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: csc
-  version: 0.7.0
+  version: 0.7.1
   repository: https://lsst-ts.github.io/charts/

--- a/apps/atqueue/values-ncsa-teststand.yaml
+++ b/apps/atqueue/values-ncsa-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/scriptqueue
-    tag: c0016
+    tag: c0017
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/atscheduler/requirements.yaml
+++ b/apps/atscheduler/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: csc
-  version: 0.6.1
+  version: 0.7.1
   repository: https://lsst-ts.github.io/charts/

--- a/apps/atscheduler/values-ncsa-teststand.yaml
+++ b/apps/atscheduler/values-ncsa-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/scheduler
-    tag: c0016
+    tag: c0017
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/atspectrograph/requirements.yaml
+++ b/apps/atspectrograph/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: csc
-  version: 0.6.1
+  version: 0.7.1
   repository: https://lsst-ts.github.io/charts/

--- a/apps/atspectrograph/values-ncsa-teststand.yaml
+++ b/apps/atspectrograph/values-ncsa-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/atspec
-    tag: c0016
+    tag: c0017
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/ccheaderservice/requirements.yaml
+++ b/apps/ccheaderservice/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: csc
-  version: 0.6.2
+  version: 0.7.1
   repository: https://lsst-ts.github.io/charts/

--- a/apps/dimm/requirements.yaml
+++ b/apps/dimm/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: csc
-  version: 0.6.1
+  version: 0.7.1
   repository: https://lsst-ts.github.io/charts/

--- a/apps/dsm/requirements.yaml
+++ b/apps/dsm/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: csc
-  version: 0.6.2
+  version: 0.7.1
   repository: https://lsst-ts.github.io/charts/

--- a/apps/dsm/values-dsm1.yaml
+++ b/apps/dsm/values-dsm1.yaml
@@ -1,4 +1,4 @@
 csc:
   env:
     CSC_INDEX: 1
-    RUN_ARG: --simulate 1
+    RUN_ARG: --simulate 1 --state enabled

--- a/apps/dsm/values-dsm2.yaml
+++ b/apps/dsm/values-dsm2.yaml
@@ -1,4 +1,4 @@
 csc:
   env:
     CSC_INDEX: 2
-    RUN_ARG: --simulate 2
+    RUN_ARG: --simulate 2 --state enabled

--- a/apps/dsm/values-ncsa-teststand.yaml
+++ b/apps/dsm/values-ncsa-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/dsm
-    tag: c0016
+    tag: c0017
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/kafka-producers/requirements.yaml
+++ b/apps/kafka-producers/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: kafka-producers
-  version: 0.6.4
+  version: 0.7.0
   repository: https://lsst-ts.github.io/charts/

--- a/apps/kafka-producers/values-ncsa-teststand.yaml
+++ b/apps/kafka-producers/values-ncsa-teststand.yaml
@@ -1,7 +1,7 @@
 kafka-producers:
   image:
     repository: ts-dockerhub.lsst.org/salkafka
-    tag: c0016
+    tag: c0017
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
@@ -26,6 +26,9 @@ kafka-producers:
         MTDome
         MTDomeTrajectory
         MTPtg
+    mtmount:
+      cscs: >-
+        MTMount
     m1m3:
       cscs: --file m1m3.yaml
       env:

--- a/apps/mtaos/requirements.yaml
+++ b/apps/mtaos/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: csc
-  version: 0.6.1
+  version: 0.7.1
   repository: https://lsst-ts.github.io/charts/

--- a/apps/mtaos/values-ncsa-teststand.yaml
+++ b/apps/mtaos/values-ncsa-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/mtaos_sim
-    tag: c0016
+    tag: c0017
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/mtcamhexapod/requirements.yaml
+++ b/apps/mtcamhexapod/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: csc
-  version: 0.6.1
+  version: 0.7.1
   repository: https://lsst-ts.github.io/charts/

--- a/apps/mtcamhexapod/values-ncsa-teststand.yaml
+++ b/apps/mtcamhexapod/values-ncsa-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/mthexapod
-    tag: c0016
+    tag: c0017
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/mtdome/requirements.yaml
+++ b/apps/mtdome/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: csc
-  version: 0.6.1
+  version: 0.7.1
   repository: https://lsst-ts.github.io/charts/

--- a/apps/mtdome/values-ncsa-teststand.yaml
+++ b/apps/mtdome/values-ncsa-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/mtdome
-    tag: c0016
+    tag: c0017
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/mtdometrajectory/requirements.yaml
+++ b/apps/mtdometrajectory/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: csc
-  version: 0.6.1
+  version: 0.7.1
   repository: https://lsst-ts.github.io/charts/

--- a/apps/mtdometrajectory/values-ncsa-teststand.yaml
+++ b/apps/mtdometrajectory/values-ncsa-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/mtdometrajectory
-    tag: c0016
+    tag: c0017
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/mtm1m3/requirements.yaml
+++ b/apps/mtm1m3/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: csc
-  version: 0.6.1
+  version: 0.7.1
   repository: https://lsst-ts.github.io/charts/

--- a/apps/mtm2/requirements.yaml
+++ b/apps/mtm2/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: csc
-  version: 0.6.1
+  version: 0.7.1
   repository: https://lsst-ts.github.io/charts/

--- a/apps/mtm2hexapod/requirements.yaml
+++ b/apps/mtm2hexapod/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: csc
-  version: 0.6.1
+  version: 0.7.1
   repository: https://lsst-ts.github.io/charts/

--- a/apps/mtm2hexapod/values-ncsa-teststand.yaml
+++ b/apps/mtm2hexapod/values-ncsa-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/mthexapod
-    tag: c0016
+    tag: c0017
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/mtmount/requirements.yaml
+++ b/apps/mtmount/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: csc
-  version: 0.6.1
+  version: 0.7.1
   repository: https://lsst-ts.github.io/charts/

--- a/apps/mtmount/values-ncsa-teststand.yaml
+++ b/apps/mtmount/values-ncsa-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/mtmount
-    tag: c0016
+    tag: c0017
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/mtptg/requirements.yaml
+++ b/apps/mtptg/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: csc
-  version: 0.6.1
+  version: 0.7.1
   repository: https://lsst-ts.github.io/charts/

--- a/apps/mtptg/values-ncsa-teststand.yaml
+++ b/apps/mtptg/values-ncsa-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/ptkernel
-    tag: c0016
+    tag: c0017
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/mtqueue/requirements.yaml
+++ b/apps/mtqueue/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: csc
-  version: 0.7.0
+  version: 0.7.1
   repository: https://lsst-ts.github.io/charts/

--- a/apps/mtqueue/values-ncsa-teststand.yaml
+++ b/apps/mtqueue/values-ncsa-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/scriptqueue
-    tag: c0016
+    tag: c0017
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/mtrotator/requirements.yaml
+++ b/apps/mtrotator/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: csc
-  version: 0.6.1
+  version: 0.7.1
   repository: https://lsst-ts.github.io/charts/

--- a/apps/mtrotator/values-ncsa-teststand.yaml
+++ b/apps/mtrotator/values-ncsa-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/mtrotator
-    tag: c0016
+    tag: c0017
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/mtscheduler/requirements.yaml
+++ b/apps/mtscheduler/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: csc
-  version: 0.6.1
+  version: 0.7.1
   repository: https://lsst-ts.github.io/charts/

--- a/apps/mtscheduler/values-ncsa-teststand.yaml
+++ b/apps/mtscheduler/values-ncsa-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/scheduler
-    tag: c0016
+    tag: c0017
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/ospl-config/requirements.yaml
+++ b/apps/ospl-config/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: ospl-config
-  version: 0.5.10
+  version: 0.5.13
   repository: https://lsst-ts.github.io/charts/

--- a/apps/ospl-daemon/requirements.yaml
+++ b/apps/ospl-daemon/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: ospl-daemon
-  version: 0.1.2
+  version: 0.2.0
   repository: https://lsst-ts.github.io/charts/

--- a/apps/ospl-daemon/values-ncsa-teststand.yaml
+++ b/apps/ospl-daemon/values-ncsa-teststand.yaml
@@ -1,7 +1,7 @@
 ospl-daemon:
   image:
     repository: ts-dockerhub.lsst.org/ospl-daemon
-    tag: c0016
+    tag: c0017
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/test-csc/requirements.yaml
+++ b/apps/test-csc/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: csc
-  version: 0.6.1
+  version: 0.7.1
   repository: https://lsst-ts.github.io/charts/

--- a/apps/test-csc/values-ncsa-teststand.yaml
+++ b/apps/test-csc/values-ncsa-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/test_csc
-    tag: c0016
+    tag: c0017
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/watcher/requirements.yaml
+++ b/apps/watcher/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: csc
-  version: 0.6.1
+  version: 0.7.1
   repository: https://lsst-ts.github.io/charts/

--- a/apps/watcher/values-ncsa-teststand.yaml
+++ b/apps/watcher/values-ncsa-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/watcher
-    tag: c0016
+    tag: c0017
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/weatherstation/requirements.yaml
+++ b/apps/weatherstation/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: csc
-  version: 0.6.1
+  version: 0.7.1
   repository: https://lsst-ts.github.io/charts/


### PR DESCRIPTION
* Update image tags to new cycle build.
* Make DSMs auto transition to ENABLED state.
* Update chart versions.
* Remove NewMTMount from NCSA kafka-producer.