### PR TITLE
Summit: Cycle 21 upgrade

### DIFF
--- a/apps/adamsensors/values-summit.yaml
+++ b/apps/adamsensors/values-summit.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/adam-sensors
-    tag: c0020
+    tag: c0021
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/ataos/values-summit.yaml
+++ b/apps/ataos/values-summit.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/ataos
-    tag: c0020
+    tag: c0021
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/atdome/values-summit.yaml
+++ b/apps/atdome/values-summit.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/atdome
-    tag: c0020
+    tag: c0021
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/atdometrajectory/values-summit.yaml
+++ b/apps/atdometrajectory/values-summit.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/atdometrajectory
-    tag: c0020
+    tag: c0021
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/atheaderservice/values-summit.yaml
+++ b/apps/atheaderservice/values-summit.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/headerservice
-    tag: ts-v2.9.1_salobj_v6.3.4_idl_v3.1.2_xml_v9.0.0_c0020
+    tag: ts-v2.9.1_salobj_v6.4.1_idl_v3.1.3_xml_v9.1.1_c0021
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/athexapod/values-summit.yaml
+++ b/apps/athexapod/values-summit.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/athexapod
-    tag: c0020
+    tag: c0021
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/atptg/values-summit.yaml
+++ b/apps/atptg/values-summit.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/ptkernel
-    tag: c0020
+    tag: c0021
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/atqueue/values-summit.yaml
+++ b/apps/atqueue/values-summit.yaml
@@ -1,13 +1,23 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/scriptqueue
-    tag: c0020
+    tag: c0021
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: summit
   shmemDir: /run/ospl
   nfsMountpoint:
+  - name: auxtel-gen3-data
+    containerPath: /repo/LATISS
+    readOnly: true
+    server: atarchiver.cp.lsst.org
+    serverPath: /repo/LATISS
+  - name: comcam-gen3-data
+    containerPath: /repo/LSSTComCam
+    readOnly: true
+    server: comcam-arctl01.cp.lsst.org
+    serverPath: /repo/LSSTComCam
   - name: auxtel-data
     containerPath: /readonly/lsstdata/auxtel
     readOnly: true

--- a/apps/atscheduler/values-summit.yaml
+++ b/apps/atscheduler/values-summit.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/scheduler
-    tag: c0020
+    tag: c0021
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/atspectrograph/values-summit.yaml
+++ b/apps/atspectrograph/values-summit.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/atspec
-    tag: c0020
+    tag: c0021
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/ccheaderservice/values-summit.yaml
+++ b/apps/ccheaderservice/values-summit.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/headerservice
-    tag: ts-v2.9.0_salobj_v6.3.4_idl_v3.1.2_xml_v9.0.0_c0020
+    tag: ts-v2.9.1_salobj_v6.4.1_idl_v3.1.3_xml_v9.1.1_c0021
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/dimm/values-summit.yaml
+++ b/apps/dimm/values-summit.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/dimm
-    tag: c0020
+    tag: c0021
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/kafka-producers/values-summit.yaml
+++ b/apps/kafka-producers/values-summit.yaml
@@ -1,7 +1,7 @@
 kafka-producers:
   image:
     repository: ts-dockerhub.lsst.org/salkafka
-    tag: c0020
+    tag: c0021
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/mtaos/values-summit.yaml
+++ b/apps/mtaos/values-summit.yaml
@@ -1,13 +1,18 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/mtaos
-    tag: c0020
+    tag: c0021
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: summit
   shmemDir: /run/ospl
   nfsMountpoint:
+  - name: comcam-gen3-data
+    containerPath: /repo/LSSTComCam
+    readOnly: true
+    server: comcam-arctl01.cp.lsst.org
+    serverPath: /repo/LSSTComCam
   - name: comcam-data
     containerPath: /readonly/lsstdata/comcam
     readOnly: true

--- a/apps/mtcamhexapod/values-summit.yaml
+++ b/apps/mtcamhexapod/values-summit.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/hexapod
-    tag: c0020
+    tag: c0021
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/mtdome/values-summit.yaml
+++ b/apps/mtdome/values-summit.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/mtdome
-    tag: c0020
+    tag: c0021
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/mtdometrajectory/values-summit.yaml
+++ b/apps/mtdometrajectory/values-summit.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/mtdometrajectory
-    tag: c0020
+    tag: c0021
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/mtm2hexapod/values-summit.yaml
+++ b/apps/mtm2hexapod/values-summit.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/hexapod
-    tag: c0020
+    tag: c0021
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/mtmount/values-summit.yaml
+++ b/apps/mtmount/values-summit.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/mtmount
-    tag: c0020
+    tag: c0021
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/mtptg/values-summit.yaml
+++ b/apps/mtptg/values-summit.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/ptkernel
-    tag: c0020
+    tag: c0021
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/mtqueue/values-summit.yaml
+++ b/apps/mtqueue/values-summit.yaml
@@ -1,13 +1,23 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/scriptqueue
-    tag: c0020
+    tag: c0021
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: summit
   shmemDir: /run/ospl
   nfsMountpoint:
+  - name: auxtel-gen3-data
+    containerPath: /repo/LATISS
+    readOnly: true
+    server: atarchiver.cp.lsst.org
+    serverPath: /repo/LATISS
+  - name: comcam-gen3-data
+    containerPath: /repo/LSSTComCam
+    readOnly: true
+    server: comcam-arctl01.cp.lsst.org
+    serverPath: /repo/LSSTComCam
   - name: auxtel-data
     containerPath: /readonly/lsstdata/auxtel
     readOnly: true

--- a/apps/mtrotator/values-summit.yaml
+++ b/apps/mtrotator/values-summit.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/mtrotator
-    tag: c0020
+    tag: c0021
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/mtscheduler/values-summit.yaml
+++ b/apps/mtscheduler/values-summit.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/scheduler
-    tag: c0020
+    tag: c0021
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/ocps/values-summit.yaml
+++ b/apps/ocps/values-summit.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/dmocps
-    tag: c0020
+    tag: c0021
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/ospl-daemon/values-summit.yaml
+++ b/apps/ospl-daemon/values-summit.yaml
@@ -1,7 +1,7 @@
 ospl-daemon:
   image:
     repository: ts-dockerhub.lsst.org/ospl-daemon
-    tag: c0020
+    tag: c0021
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/watcher/values-summit.yaml
+++ b/apps/watcher/values-summit.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/watcher
-    tag: c0020
+    tag: c0021
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/weatherstation/values-summit.yaml
+++ b/apps/weatherstation/values-summit.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/weatherstation
-    tag: c0020
+    tag: c0021
     pullPolicy: Always
     nexus3: nexus3-docker
   env:


### PR DESCRIPTION
* Update image tags.
* Update HS version.
* Add Gen3 repos to MTAOS and ScriptQueues.