### PR TITLE
Summit: Update HeaderService configuration for LFA

### DIFF
--- a/apps/atheaderservice/values-summit.yaml
+++ b/apps/atheaderservice/values-summit.yaml
@@ -7,18 +7,22 @@ csc:
   env:
     LSST_DDS_PARTITION_PREFIX: summit
     LSST_DDS_RESPONSIVENESS_TIMEOUT: 15s
-    IP_HEADERSERVICE: atheaderservice.cp.lsst.org
-    URL_SPEC: --url_format http://{ip_address}/{filename_HDR}
-    PORT_SPEC: --port_number 8008
-  pvcMountpoint:
-  - name: www
-    path: /home/saluser/www
-    accessMode: ReadWriteOnce
-    claimSize: 50Gi
-    storageClass: rook-ceph-block
+    URL_SPEC: --lfa_mode s3 --s3instance cp
+    S3_ENDPOINT_URL: https://s3.cp.lsst.org
+  envSecrets:
+  - name: AWS_ACCESS_KEY_ID
+    secretName: lfa
+    secretKey: aws-access-key-id
+  - name: AWS_SECRET_ACCESS_KEY
+    secretName: lfa
+    secretKey: aws-secret-access-key
+  - name: MYS3_ACCESS_KEY
+    secretName: lfa
+    secretKey: aws-access-key-id
+  - name: MYS3_SECRET_KEY
+    secretName: lfa
+    secretKey: aws-secret-access-key
   shmemDir: /run/ospl
   osplVersion: V6.10.4
 ingress:
-  use: true
-  hostname: atheaderservice.cp.lsst.org
-  port: 8008
+  use: false

--- a/apps/ccheaderservice/values-summit.yaml
+++ b/apps/ccheaderservice/values-summit.yaml
@@ -7,8 +7,8 @@ csc:
   env:
     LSST_DDS_PARTITION_PREFIX: summit
     LSST_DDS_RESPONSIVENESS_TIMEOUT: 15s
-    IP_HEADERSERVICE: ccheaderservice.cp.lsst.org
-    URL_SPEC: --url_format http://{ip_address}/{filename_HDR}
+    URL_SPEC: --lfa_mode s3 --s3instance cp
+    S3_ENDPOINT_URL: https://s3.cp.lsst.org
   envSecrets:
   - name: AWS_ACCESS_KEY_ID
     secretName: lfa
@@ -22,15 +22,7 @@ csc:
   - name: MYS3_SECRET_KEY
     secretName: lfa
     secretKey: aws-secret-access-key
-  pvcMountpoint:
-  - name: www
-    path: /home/saluser/www
-    accessMode: ReadWriteOnce
-    claimSize: 50Gi
-    storageClass: rook-ceph-block
   shmemDir: /run/ospl
   osplVersion: V6.10.4
 ingress:
-  use: true
-  hostname: ccheaderservice.cp.lsst.org
-  port: 8000
+  use: false

--- a/docs/ops/atheaderservice.rst
+++ b/docs/ops/atheaderservice.rst
@@ -16,5 +16,3 @@ atheaderservice
 
 This application handles creating header files for LATISS (also known as ATCamera).
 The application is managed by the `csc Helm chart <https://github.com/lsst-ts/charts/tree/master/charts/csc>`_.
-It uses extra API specifications to handle the web service used to server the header files.
-Those specifications are in ``apps/atheaderservice/templates``.

--- a/docs/ops/ccheaderservice.rst
+++ b/docs/ops/ccheaderservice.rst
@@ -16,5 +16,3 @@ ccheaderservice
 
 This application handles creating header files for ComCam (also known as CCCamera).
 The application is managed by the `csc Helm chart <https://github.com/lsst-ts/charts/tree/master/charts/csc>`_.
-It uses extra API specifications to handle the web service used to server the header files.
-Those specifications are in ``apps/ccheaderservice/templates``.


### PR DESCRIPTION
* Switch CCHS to S3 LFA.
* Switch ATHS to S3 LFA.
* Update documentation.