### PR TITLE
Summit: tickets/DM-32652

### DIFF
--- a/apps/maintel/values-summit.yaml
+++ b/apps/maintel/values-summit.yaml
@@ -12,4 +12,3 @@ cscs:
   - mtm2hexapod
 runAsSim:
   - mtdome
-  - mtrotator

--- a/apps/mtcamhexapod/values-summit-sim.yaml
+++ b/apps/mtcamhexapod/values-summit-sim.yaml
@@ -1,0 +1,5 @@
+csc:
+  image:
+    tag: c0022
+  env:
+    RUN_ARG: --simulate 1

--- a/apps/mtm2hexapod/values-summit-sim.yaml
+++ b/apps/mtm2hexapod/values-summit-sim.yaml
@@ -1,0 +1,5 @@
+csc:
+  image:
+    tag: c0022
+  env:
+    RUN_ARG: --simulate 2

--- a/apps/mtm2hexapod/values-summit.yaml
+++ b/apps/mtm2hexapod/values-summit.yaml
@@ -6,7 +6,7 @@ csc:
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: summit
-    RUN_ARG: --simulate 2
+    RUN_ARG: 2
   shmemDir: /run/ospl
   osplVersion: V6.10.4
 ingress:

--- a/apps/mtmount/values-summit-sim.yaml
+++ b/apps/mtmount/values-summit-sim.yaml
@@ -1,0 +1,5 @@
+csc:
+  image:
+    tag: c0022
+  env:
+    RUN_ARG: --simulate

--- a/apps/mtrotator/values-summit-sim.yaml
+++ b/apps/mtrotator/values-summit-sim.yaml
@@ -1,0 +1,5 @@
+csc:
+  image:
+    tag: c0022
+  env:
+    RUN_ARG: --simulate


### PR DESCRIPTION
Summit: Split real and simulator containers for some maintel apps. 

* Add simulator configs for maintel apps.
* Fix configuration for M2Hexapod.
* Remove rotator from simulator list.