### PR TITLE
TTS: All changes up through cycle 23.

### DIFF
--- a/apps/ataos/values-tucson-teststand.yaml
+++ b/apps/ataos/values-tucson-teststand.yaml
@@ -1,0 +1,10 @@
+csc:
+  image:
+    repository: ts-dockerhub.lsst.org/ataos
+    tag: c0023
+    pullPolicy: Always
+    nexus3: nexus3-docker
+  env:
+    LSST_DDS_PARTITION_PREFIX: tucson
+  shmemDir: /run/ospl
+  osplVersion: V6.10.4

--- a/apps/atdome/values-tucson-teststand.yaml
+++ b/apps/atdome/values-tucson-teststand.yaml
@@ -1,0 +1,11 @@
+csc:
+  image:
+    repository: ts-dockerhub.lsst.org/atdome
+    tag: c0023
+    pullPolicy: Always
+    nexus3: nexus3-docker
+  env:
+    LSST_DDS_PARTITION_PREFIX: tucson
+    RUN_ARG: --simulate
+  shmemDir: /run/ospl
+  osplVersion: V6.10.4

--- a/apps/atdometrajectory/values-tucson-teststand.yaml
+++ b/apps/atdometrajectory/values-tucson-teststand.yaml
@@ -1,0 +1,10 @@
+csc:
+  image:
+    repository: ts-dockerhub.lsst.org/atdometrajectory
+    tag: c0023
+    pullPolicy: Always
+    nexus3: nexus3-docker
+  env:
+    LSST_DDS_PARTITION_PREFIX: tucson
+  shmemDir: /run/ospl
+  osplVersion: V6.10.4

--- a/apps/atheaderservice/values-tucson-teststand.yaml
+++ b/apps/atheaderservice/values-tucson-teststand.yaml
@@ -1,0 +1,29 @@
+csc:
+  image:
+    repository: ts-dockerhub.lsst.org/headerservice
+    tag: ts-v2.9.4_salobj_v6.7.0_idl_v3.5.0_xml_v10.1.0_c0023
+    pullPolicy: Always
+    nexus3: nexus3-docker
+  env:
+    LSST_DDS_PARTITION_PREFIX: tucson
+    LSST_DDS_RESPONSIVENESS_TIMEOUT: 15s
+    URL_SPEC: --lfa_mode s3 --s3instance tuc
+    S3_ENDPOINT_URL: https://s3.tu.lsst.org
+    TSTAND_HEADERSERVICE: TUCSON
+  envSecrets:
+  - name: AWS_ACCESS_KEY_ID
+    secretName: lfa
+    secretKey: aws-access-key-id
+  - name: AWS_SECRET_ACCESS_KEY
+    secretName: lfa
+    secretKey: aws-secret-access-key
+  - name: MYS3_ACCESS_KEY
+    secretName: lfa
+    secretKey: aws-access-key-id
+  - name: MYS3_SECRET_KEY
+    secretName: lfa
+    secretKey: aws-secret-access-key
+  shmemDir: /run/ospl
+  osplVersion: V6.10.4
+ingress:
+  use: false

--- a/apps/athexapod/values-tucson-teststand.yaml
+++ b/apps/athexapod/values-tucson-teststand.yaml
@@ -1,0 +1,10 @@
+csc:
+  image:
+    repository: ts-dockerhub.lsst.org/athexapod
+    tag: c0023
+    pullPolicy: Always
+    nexus3: nexus3-docker
+  env:
+    LSST_DDS_PARTITION_PREFIX: tucson
+  shmemDir: /run/ospl
+  osplVersion: V6.10.4

--- a/apps/atmcs/values-tucson-teststand.yaml
+++ b/apps/atmcs/values-tucson-teststand.yaml
@@ -1,0 +1,10 @@
+csc:
+  image:
+    repository: ts-dockerhub.lsst.org/atmcs_sim
+    tag: c0023
+    pullPolicy: Always
+    nexus3: nexus3-docker
+  env:
+    LSST_DDS_PARTITION_PREFIX: tucson
+  shmemDir: /run/ospl
+  osplVersion: V6.10.4

--- a/apps/atocps/values-tucson-teststand.yaml
+++ b/apps/atocps/values-tucson-teststand.yaml
@@ -1,0 +1,10 @@
+csc:
+  image:
+    repository: ts-dockerhub.lsst.org/dmocps
+    tag: c0023
+    pullPolicy: Always
+    nexus3: nexus3-docker
+  env:
+    LSST_DDS_PARTITION_PREFIX: tucson
+  shmemDir: /run/ospl
+  osplVersion: V6.10.4

--- a/apps/atpneumatics/values-tucson-teststand.yaml
+++ b/apps/atpneumatics/values-tucson-teststand.yaml
@@ -1,0 +1,10 @@
+csc:
+  image:
+    repository: ts-dockerhub.lsst.org/at_pneumatics_sim
+    tag: c0023
+    pullPolicy: Always
+    nexus3: nexus3-docker
+  env:
+    LSST_DDS_PARTITION_PREFIX: tucson
+  shmemDir: /run/ospl
+  osplVersion: V6.10.4

--- a/apps/atptg/values-tucson-teststand.yaml
+++ b/apps/atptg/values-tucson-teststand.yaml
@@ -1,0 +1,10 @@
+csc:
+  image:
+    repository: ts-dockerhub.lsst.org/ptkernel
+    tag: c0023
+    pullPolicy: Always
+    nexus3: nexus3-docker
+  env:
+    LSST_DDS_PARTITION_PREFIX: tucson
+  shmemDir: /run/ospl
+  osplVersion: V6.10.4

--- a/apps/atqueue/values-tucson-teststand.yaml
+++ b/apps/atqueue/values-tucson-teststand.yaml
@@ -1,0 +1,32 @@
+csc:
+  image:
+    repository: ts-dockerhub.lsst.org/scriptqueue
+    tag: c0023
+    pullPolicy: Always
+    nexus3: nexus3-docker
+  env:
+    LSST_DDS_PARTITION_PREFIX: tucson
+    RUN_ARG: 2 --state enabled
+  shmemDir: /run/ospl
+  osplVersion: V6.10.4
+  nfsMountpoint:
+  - name: auxtel-gen3-butler
+    containerPath: /repo/LATISS
+    readOnly: false
+    server: auxtel-archiver.tu.lsst.org
+    serverPath: /repo/LATISS
+  - name: auxtel-gen3-oods
+    containerPath: /data/lsstdata/TTS/auxtel
+    readOnly: true
+    server: auxtel-archiver.tu.lsst.org
+    serverPath: /lsstdata/TTS/auxtel
+  - name: comcam-gen3-butler
+    containerPath: /repo/LSSTComCam
+    readOnly: false
+    server: comcam-archiver.tu.lsst.org
+    serverPath: /repo/LSSTComCam
+  - name: comcam-gen3-oods
+    containerPath: /data/lsstdata/TTS/comcam
+    readOnly: true
+    server: comcam-archiver.tu.lsst.org
+    serverPath: /lsstdata/TTS/comcam

--- a/apps/atscheduler/values-tucson-teststand.yaml
+++ b/apps/atscheduler/values-tucson-teststand.yaml
@@ -1,0 +1,30 @@
+csc:
+  image:
+    repository: ts-dockerhub.lsst.org/scheduler
+    tag: c0023
+    pullPolicy: Always
+    nexus3: nexus3-docker
+  env:
+    LSST_DDS_PARTITION_PREFIX: tucson
+    S3_ENDPOINT_URL: https://s3.tu.lsst.org
+  envSecrets:
+  - name: AWS_ACCESS_KEY_ID
+    secretName: lfa
+    secretKey: aws-access-key-id
+  - name: AWS_SECRET_ACCESS_KEY
+    secretName: lfa
+    secretKey: aws-secret-access-key
+  - name: MYS3_ACCESS_KEY
+    secretName: lfa
+    secretKey: aws-access-key-id
+  - name: MYS3_SECRET_KEY
+    secretName: lfa
+    secretKey: aws-secret-access-key
+  shmemDir: /run/ospl
+  osplVersion: V6.10.4
+  nfsMountpoint:
+  - name: rubin-sim-data
+    containerPath: /home/saluser/rubin_sim_data
+    readOnly: true
+    server: nfs-scratch.tu.lsst.org
+    serverPath: /scratch/scheduler

--- a/apps/atspectrograph/values-tucson-teststand.yaml
+++ b/apps/atspectrograph/values-tucson-teststand.yaml
@@ -1,0 +1,11 @@
+csc:
+  image:
+    repository: ts-dockerhub.lsst.org/atspec
+    tag: c0023
+    pullPolicy: Always
+    nexus3: nexus3-docker
+  env:
+    LSST_DDS_PARTITION_PREFIX: tucson
+    RUN_ARG: --simulate
+  shmemDir: /run/ospl
+  osplVersion: V6.10.4

--- a/apps/auxtel/values-tucson-teststand.yaml
+++ b/apps/auxtel/values-tucson-teststand.yaml
@@ -1,0 +1,13 @@
+env: tucson-teststand
+cscs:
+  - ataos
+  - atdome
+  - atdometrajectory
+  - atheaderservice
+  - athexapod
+  - atptg
+  - atspectrograph
+  - hexapodsim
+spec:
+  source:
+    targetRevision: tickets/DM-30329

--- a/apps/auxtel/values.yaml
+++ b/apps/auxtel/values.yaml
@@ -9,3 +9,4 @@ noSim:
   - ataos
   - atdometrajectory
   - atptg
+  - atheaderservice

--- a/apps/ccheaderservice/values-tucson-teststand.yaml
+++ b/apps/ccheaderservice/values-tucson-teststand.yaml
@@ -1,0 +1,29 @@
+csc:
+  image:
+    repository: ts-dockerhub.lsst.org/headerservice
+    tag: ts-v2.9.4_salobj_v6.7.0_idl_v3.5.0_xml_v10.1.0_c0023
+    pullPolicy: Always
+    nexus3: nexus3-docker
+  env:
+    LSST_DDS_PARTITION_PREFIX: tucson
+    LSST_DDS_RESPONSIVENESS_TIMEOUT: 15s
+    URL_SPEC: --lfa_mode s3 --s3instance tuc
+    S3_ENDPOINT_URL: https://s3.tu.lsst.org
+    TSTAND_HEADERSERVICE: TUCSON
+  envSecrets:
+  - name: AWS_ACCESS_KEY_ID
+    secretName: lfa
+    secretKey: aws-access-key-id
+  - name: AWS_SECRET_ACCESS_KEY
+    secretName: lfa
+    secretKey: aws-secret-access-key
+  - name: MYS3_ACCESS_KEY
+    secretName: lfa
+    secretKey: aws-access-key-id
+  - name: MYS3_SECRET_KEY
+    secretName: lfa
+    secretKey: aws-secret-access-key
+  shmemDir: /run/ospl
+  osplVersion: V6.10.4
+ingress:
+  use: false

--- a/apps/ccocps/values-tucson-teststand.yaml
+++ b/apps/ccocps/values-tucson-teststand.yaml
@@ -1,0 +1,10 @@
+csc:
+  image:
+    repository: ts-dockerhub.lsst.org/dmocps
+    tag: c0023
+    pullPolicy: Always
+    nexus3: nexus3-docker
+  env:
+    LSST_DDS_PARTITION_PREFIX: tucson
+  shmemDir: /run/ospl
+  osplVersion: V6.10.4

--- a/apps/cluster-config/values-tucson-teststand.yaml
+++ b/apps/cluster-config/values-tucson-teststand.yaml
@@ -1,0 +1,15 @@
+cluster-config:
+  vaultPathPrefix: secret/k8s_operator/tucson-teststand.lsst.codes
+  secrets:
+    - name: nexus3-docker
+      key: pull-secret
+      type: kubernetes.io/dockerconfigjson
+      namespaces:
+        - namespaces
+        - uws
+    - name: lfa
+      key: ts/software/lfa
+      namespaces:
+        - auxtel
+        - maintel
+        - obssys

--- a/apps/dimm/values-tucson-teststand.yaml
+++ b/apps/dimm/values-tucson-teststand.yaml
@@ -1,0 +1,10 @@
+csc:
+  image:
+    repository: ts-dockerhub.lsst.org/dimm
+    tag: c0023
+    pullPolicy: Always
+    nexus3: nexus3-docker
+  env:
+    LSST_DDS_PARTITION_PREFIX: tucson
+  shmemDir: /run/ospl
+  osplVersion: V6.10.4

--- a/apps/dmocps/values-tucson-teststand.yaml
+++ b/apps/dmocps/values-tucson-teststand.yaml
@@ -1,4 +1,7 @@
-env: ncsa-teststand
+env: tucson-teststand
+cscs:
+  - atocps
+  - ccocps
 spec:
   source:
     targetRevision: tickets/DM-30329

--- a/apps/dsm/values-tucson-teststand.yaml
+++ b/apps/dsm/values-tucson-teststand.yaml
@@ -1,0 +1,10 @@
+csc:
+  image:
+    repository: ts-dockerhub.lsst.org/dsm
+    tag: c0023
+    pullPolicy: Always
+    nexus3: nexus3-docker
+  env:
+    LSST_DDS_PARTITION_PREFIX: tucson
+  shmemDir: /run/ospl
+  osplVersion: V6.10.4

--- a/apps/eas/values-tucson-teststand.yaml
+++ b/apps/eas/values-tucson-teststand.yaml
@@ -1,0 +1,10 @@
+env: tucson-teststand
+cscs:
+  - dsm1
+  - dsm2
+  - weatherstation1
+  - dimm1
+  - dimm2
+spec:
+  source:
+    targetRevision: tickets/DM-30329

--- a/apps/hexapodsim/values-tucson-teststand.yaml
+++ b/apps/hexapodsim/values-tucson-teststand.yaml
@@ -1,0 +1,5 @@
+image:
+  repository: ts-dockerhub.lsst.org/hexapod_simulator
+  tag: latest
+  pullPolicy: Always
+  nexus3: nexus3-docker

--- a/apps/kafka-producers/Chart.yaml
+++ b/apps/kafka-producers/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 version: 0.1.0
 dependencies:
 - name: kafka-producers
-  version: 0.10.0
+  version: 0.10.1
   repository: https://lsst-ts.github.io/charts/

--- a/apps/kafka-producers/values-tucson-teststand.yaml
+++ b/apps/kafka-producers/values-tucson-teststand.yaml
@@ -1,24 +1,30 @@
 kafka-producers:
   image:
-    repository: lsstts/salkafka
-    tag: v1.1.0_salobj_v5.4.0_xml_v4.7.0
+    repository: ts-dockerhub.lsst.org/salkafka
+    tag: c0023
     pullPolicy: Always
-
+    nexus3: nexus3-docker
   env:
-    lsstDdsDomain: tucson
-    brokerIp: kafka-0-tucson-teststand-efd.lsst.codes
-    brokerPort: 31090
-    registryAddr: https://schema-registry-tucson-teststand-efd.lsst.codes
+    lsstDdsPartitionPrefix: tucson
+    brokerIp: cp-helm-charts-cp-kafka-headless.cp-helm-charts
+    brokerPort: 9092
+    registryAddr: http://cp-helm-charts-cp-schema-registry.cp-helm-charts:8081
     partitions: 1
     replication: 3
     waitAck: 1
-    logLevel: 10
-
+    logLevel: 20
+    extras:
+      LSST_DDS_RESPONSIVENESS_TIMEOUT: 15s
+  shmemDir: /run/ospl
   producers:
-    maintel: null
-    mtmount: null
-    m1m3: null
-    m2: null
     eas:
       cscs: >-
+        DIMM
         DSM
+        WeatherStation
+  osplVersion: V6.10.4
+  startupProbe:
+    use: true
+    failureThreshold: 15
+    initialDelay: 20
+    period: 10

--- a/apps/love-commander/values-tucson-teststand.yaml
+++ b/apps/love-commander/values-tucson-teststand.yaml
@@ -1,0 +1,10 @@
+csc:
+  image:
+    repository: ts-dockerhub.lsst.org/love-commander
+    tag: c0023
+    pullPolicy: Always
+    nexus3: nexus3-docker
+  env:
+    LSST_DDS_PARTITION_PREFIX: tucson
+  shmemDir: /run/ospl
+  osplVersion: V6.10.4

--- a/apps/love-manager/values-tucson-teststand.yaml
+++ b/apps/love-manager/values-tucson-teststand.yaml
@@ -1,12 +1,12 @@
 love-manager:
   image:
     repository: ts-dockerhub.lsst.org/love-manager
-    tag: c0024
+    tag: c0023
     pullPolicy: IfNotPresent
     nexus3: nexus3-docker
-  secret_path: lsst-nts-k8s.ncsa.illinois.edu
+  secret_path: tucson-teststand.lsst.codes
   env:
-    SERVER_URL: lsst-love-nts.ncsa.illinois.edu
+    SERVER_URL: love.tu.lsst.org
     REDIS_CONFIG_EXPIRY: 5
     REDIS_CONFIG_CAPACITY: 5000
   autoscaling:
@@ -20,7 +20,7 @@ love-manager:
     storage:
       name: love-manager-database
       path: /var/lib/postgresql
-      storageClass: local-path
+      storageClass: rook-ceph-block
       accessMode: ReadWriteOnce
       claimSize: 2Gi
   redis:

--- a/apps/love-nginx/Chart.yaml
+++ b/apps/love-nginx/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 version: 0.1.0
 dependencies:
 - name: love-nginx
-  version: 0.1.6
+  version: 0.2.1
   repository: https://lsst-ts.github.io/charts/

--- a/apps/love-nginx/values-tucson-teststand.yaml
+++ b/apps/love-nginx/values-tucson-teststand.yaml
@@ -4,18 +4,18 @@ love-nginx:
     tag: 1.13.1
     pullPolicy: IfNotPresent
   ingress:
-    hostname: lsst-love-nts.ncsa.illinois.edu
+    hostname: love.tu.lsst.org
   imagePullSecrets:
   - name: love-nexus3-docker
   initContainers:
     frontend:
       image:
         repository: ts-dockerhub.lsst.org/love-frontend
-        tag: c0024
+        tag: c0023
     manager:
       image:
         repository: ts-dockerhub.lsst.org/love-manager-static
-        tag: c0024
+        tag: c0023
       command:
       - /bin/sh
       - -c
@@ -24,6 +24,6 @@ love-nginx:
         cp -Rv /usr/src/love/manager/media /usr/src/love-manager
   staticStore:
     name: love-nginx-static
-    storageClass: local-path
+    storageClass: rook-ceph-block
     accessMode: ReadWriteOnce
     claimSize: 2Gi

--- a/apps/love-producer/values-ncsa-teststand.yaml
+++ b/apps/love-producer/values-ncsa-teststand.yaml
@@ -12,4 +12,6 @@ love-producer:
     ataos: ATAOS:0
     atarchiver: ATArchiver:0
     atcamera: ATCamera:0
+    atmcs: ATMCS:0
+    atptg: ATPtg:0
   osplVersion: V6.10.4

--- a/apps/love-producer/values-tucson-teststand.yaml
+++ b/apps/love-producer/values-tucson-teststand.yaml
@@ -1,0 +1,48 @@
+love-producer:
+  image:
+    repository: ts-dockerhub.lsst.org/love-producer
+    tag: c0023
+    pullPolicy: Always
+    nexus3: nexus3-docker
+  env:
+    LSST_DDS_PARTITION_PREFIX: tucson
+    WEBSOCKET_HOST: love-nginx-service/manager/ws/subscription
+  shmemDir: /run/ospl
+  producers:
+    ataos: ATAOS:0
+    atarchiver: ATArchiver:0
+    atcamera: ATCamera:0
+    atdome: ATDome:0
+    atdometrajectory: ATDomeTrajectory:0
+    atheaderservice: ATHeaderService:0
+    athexapod: ATHexapod:0
+    atmcs: ATMCS:0
+    atpneumatics: ATPneumatics:0
+    atocps: OCPS:1
+    atptg: ATPtg:0
+    atscheduler: Scheduler:2
+    atscriptqueue: ScriptQueue:2
+    atspectrograph: ATSpectrograph:0
+    camerahexapod: MTHexapod:1
+    ccarchiver: CCArchiver:0
+    cccamera: CCCamera:0
+    ccheaderservice: CCHeaderService:0
+    ccocps: OCPS:2
+    dimm1: DIMM:1
+    dimm2: DIMM:2
+    dsm1: DSM:1
+    dsm2: DSM:2
+    love: LOVE:0
+    m2hexapod: MTHexapod:2
+    mtaos: MTAOS:0
+    mtdome: MTDome:0
+    mtdometrajectory: MTDomeTrajectory:0
+    mtm2: MTM2:0
+    mtmount: MTMount:0
+    mtptg: MTPtg:0
+    mtrotator: MTRotator:0
+    mtscheduler: Scheduler:1
+    mtscriptqueue: ScriptQueue:1
+    watcher: Watcher:0
+    weatherstation1: WeatherStation:1
+  osplVersion: V6.10.4

--- a/apps/love/values-tucson-teststand.yaml
+++ b/apps/love/values-tucson-teststand.yaml
@@ -1,4 +1,4 @@
-env: ncsa-teststand
+env: tucson-teststand
 spec:
   source:
     targetRevision: tickets/DM-30329

--- a/apps/maintel/values-tucson-teststand.yaml
+++ b/apps/maintel/values-tucson-teststand.yaml
@@ -1,0 +1,20 @@
+env: tucson-teststand
+cscs:
+  - mtaos
+  - mtptg
+  - mtcamhexapod
+  - mtm2hexapod
+  - mtmount
+  - mtrotator
+  - mtdome
+  - mtdometrajectory
+  - mtm2
+  - ccheaderservice
+noSim:
+  - mtaos
+  - mtptg
+  - mtdometrajectory
+  - ccheaderservice
+spec:
+  source:
+    targetRevision: tickets/DM-30329

--- a/apps/maintel/values.yaml
+++ b/apps/maintel/values.yaml
@@ -8,3 +8,4 @@ spec:
 noSim:
   - mtptg
   - mtdometrajectory
+  - ccheaderservice

--- a/apps/mtaos/values-tucson-teststand.yaml
+++ b/apps/mtaos/values-tucson-teststand.yaml
@@ -1,0 +1,21 @@
+csc:
+  image:
+    repository: ts-dockerhub.lsst.org/mtaos
+    tag: c0023
+    pullPolicy: Always
+    nexus3: nexus3-docker
+  env:
+    LSST_DDS_PARTITION_PREFIX: tucson
+  shmemDir: /run/ospl
+  osplVersion: V6.10.4
+  nfsMountpoint:
+  - name: comcam-gen3-butler
+    containerPath: /repo/LSSTComCam
+    readOnly: false
+    server: comcam-archiver.tu.lsst.org
+    serverPath: /repo/LSSTComCam
+  - name: comcam-gen3-oods
+    containerPath: /data/lsstdata/TTS/comcam
+    readOnly: true
+    server: comcam-archiver.tu.lsst.org
+    serverPath: /lsstdata/TTS/comcam

--- a/apps/mtcamhexapod/values-tucson-teststand.yaml
+++ b/apps/mtcamhexapod/values-tucson-teststand.yaml
@@ -1,0 +1,11 @@
+csc:
+  image:
+    repository: ts-dockerhub.lsst.org/mthexapod
+    tag: c0023
+    pullPolicy: Always
+    nexus3: nexus3-docker
+  env:
+    LSST_DDS_PARTITION_PREFIX: tucson
+    RUN_ARG: --simulate 1
+  shmemDir: /run/ospl
+  osplVersion: V6.10.4

--- a/apps/mtdome/values-tucson-teststand.yaml
+++ b/apps/mtdome/values-tucson-teststand.yaml
@@ -1,0 +1,11 @@
+csc:
+  image:
+    repository: ts-dockerhub.lsst.org/mtdome
+    tag: c0023
+    pullPolicy: Always
+    nexus3: nexus3-docker
+  env:
+    LSST_DDS_PARTITION_PREFIX: tucson
+    RUN_ARG: --simulate
+  shmemDir: /run/ospl
+  osplVersion: V6.10.4

--- a/apps/mtdometrajectory/values-tucson-teststand.yaml
+++ b/apps/mtdometrajectory/values-tucson-teststand.yaml
@@ -1,0 +1,10 @@
+csc:
+  image:
+    repository: ts-dockerhub.lsst.org/mtdometrajectory
+    tag: c0023
+    pullPolicy: Always
+    nexus3: nexus3-docker
+  env:
+    LSST_DDS_PARTITION_PREFIX: tucson
+  shmemDir: /run/ospl
+  osplVersion: V6.10.4

--- a/apps/mtm2/values-tucson-teststand.yaml
+++ b/apps/mtm2/values-tucson-teststand.yaml
@@ -1,0 +1,11 @@
+csc:
+  image:
+    repository: ts-dockerhub.lsst.org/m2
+    tag: c0023
+    pullPolicy: Always
+    nexus3: nexus3-docker
+  env:
+    LSST_DDS_PARTITION_PREFIX: tucson
+    RUN_ARG: --simulate
+  shmemDir: /run/ospl
+  osplVersion: V6.10.4

--- a/apps/mtm2hexapod/values-tucson-teststand.yaml
+++ b/apps/mtm2hexapod/values-tucson-teststand.yaml
@@ -1,0 +1,11 @@
+csc:
+  image:
+    repository: ts-dockerhub.lsst.org/mthexapod
+    tag: c0023
+    pullPolicy: Always
+    nexus3: nexus3-docker
+  env:
+    LSST_DDS_PARTITION_PREFIX: tucson
+    RUN_ARG: --simulate 2
+  shmemDir: /run/ospl
+  osplVersion: V6.10.4

--- a/apps/mtmount/values-tucson-teststand.yaml
+++ b/apps/mtmount/values-tucson-teststand.yaml
@@ -1,0 +1,11 @@
+csc:
+  image:
+    repository: ts-dockerhub.lsst.org/mtmount
+    tag: c0023.009
+    pullPolicy: Always
+    nexus3: nexus3-docker
+  env:
+    LSST_DDS_PARTITION_PREFIX: tucson
+    RUN_ARG: --simulate
+  shmemDir: /run/ospl
+  osplVersion: V6.10.4

--- a/apps/mtptg/values-tucson-teststand.yaml
+++ b/apps/mtptg/values-tucson-teststand.yaml
@@ -1,0 +1,10 @@
+csc:
+  image:
+    repository: ts-dockerhub.lsst.org/ptkernel
+    tag: c0023
+    pullPolicy: Always
+    nexus3: nexus3-docker
+  env:
+    LSST_DDS_PARTITION_PREFIX: tucson
+  shmemDir: /run/ospl
+  osplVersion: V6.10.4

--- a/apps/mtqueue/values-tucson-teststand.yaml
+++ b/apps/mtqueue/values-tucson-teststand.yaml
@@ -1,0 +1,32 @@
+csc:
+  image:
+    repository: ts-dockerhub.lsst.org/scriptqueue
+    tag: c0023
+    pullPolicy: Always
+    nexus3: nexus3-docker
+  env:
+    LSST_DDS_PARTITION_PREFIX: tucson
+    RUN_ARG: 1 --state enabled
+  shmemDir: /run/ospl
+  osplVersion: V6.10.4
+  nfsMountpoint:
+  - name: auxtel-gen3-butler
+    containerPath: /repo/LATISS
+    readOnly: false
+    server: auxtel-archiver.tu.lsst.org
+    serverPath: /repo/LATISS
+  - name: auxtel-gen3-oods
+    containerPath: /data/lsstdata/TTS/auxtel
+    readOnly: true
+    server: auxtel-archiver.tu.lsst.org
+    serverPath: /lsstdata/TTS/auxtel
+  - name: comcam-gen3-butler
+    containerPath: /repo/LSSTComCam
+    readOnly: false
+    server: comcam-archiver.tu.lsst.org
+    serverPath: /repo/LSSTComCam
+  - name: comcam-gen3-oods
+    containerPath: /data/lsstdata/TTS/comcam
+    readOnly: true
+    server: comcam-archiver.tu.lsst.org
+    serverPath: /lsstdata/TTS/comcam

--- a/apps/mtrotator/values-tucson-teststand.yaml
+++ b/apps/mtrotator/values-tucson-teststand.yaml
@@ -1,0 +1,13 @@
+csc:
+  image:
+    repository: ts-dockerhub.lsst.org/mtrotator
+    tag: c0023
+    pullPolicy: Always
+    nexus3: nexus3-docker
+  env:
+    LSST_DDS_PARTITION_PREFIX: tucson
+    RUN_ARG: --simulate
+  shmemDir: /run/ospl
+  osplVersion: V6.10.4
+ingress:
+  use: false

--- a/apps/mtscheduler/values-tucson-teststand.yaml
+++ b/apps/mtscheduler/values-tucson-teststand.yaml
@@ -1,0 +1,30 @@
+csc:
+  image:
+    repository: ts-dockerhub.lsst.org/scheduler
+    tag: c0023
+    pullPolicy: Always
+    nexus3: nexus3-docker
+  env:
+    LSST_DDS_PARTITION_PREFIX: tucson
+    S3_ENDPOINT_URL: https://s3.tu.lsst.org
+  envSecrets:
+  - name: AWS_ACCESS_KEY_ID
+    secretName: lfa
+    secretKey: aws-access-key-id
+  - name: AWS_SECRET_ACCESS_KEY
+    secretName: lfa
+    secretKey: aws-secret-access-key
+  - name: MYS3_ACCESS_KEY
+    secretName: lfa
+    secretKey: aws-access-key-id
+  - name: MYS3_SECRET_KEY
+    secretName: lfa
+    secretKey: aws-secret-access-key
+  shmemDir: /run/ospl
+  osplVersion: V6.10.4
+  nfsMountpoint:
+  - name: rubin-sim-data
+    containerPath: /home/saluser/rubin_sim_data
+    readOnly: true
+    server: nfs-scratch.tu.lsst.org
+    serverPath: /scratch/scheduler

--- a/apps/obssys/values-tucson-teststand.yaml
+++ b/apps/obssys/values-tucson-teststand.yaml
@@ -1,0 +1,10 @@
+env: tucson-teststand
+cscs:
+  - atqueue
+  - mtqueue
+  - watcher
+  - atscheduler
+  - mtscheduler
+spec:
+  source:
+    targetRevision: tickets/DM-30329

--- a/apps/ospl-config/values-tucson-teststand.yaml
+++ b/apps/ospl-config/values-tucson-teststand.yaml
@@ -1,0 +1,7 @@
+ospl-config:
+  domainId: 0
+  waterMarksWhcAdaptive: false
+  ddsi2TracingEnabled: true
+  ddsi2TracingLogfile: ddsi2.log
+  durabilityServiceTracingEnabled: true
+  durabilityServiceTracingLogfile: durability.log

--- a/apps/ospl-daemon/values-tucson-teststand.yaml
+++ b/apps/ospl-daemon/values-tucson-teststand.yaml
@@ -1,0 +1,17 @@
+ospl-daemon:
+  image:
+    repository: ts-dockerhub.lsst.org/ospl-daemon
+    tag: c0023
+    pullPolicy: Always
+    nexus3: nexus3-docker
+  env:
+    LSST_DDS_PARTITION_PREFIX: tucson
+    LSST_DDS_RESPONSIVENESS_TIMEOUT: 15s
+  annotations:
+    k8s.v1.cni.cncf.io/networks: kube-system/misc-dds
+  initContainer:
+    repository: lsstit/ddsnet4u
+    tag: latest
+    pullPolicy: Always
+  shmemDir: /run/ospl
+  osplVersion: V6.10.4

--- a/apps/ospl-main-daemon/Chart.yaml
+++ b/apps/ospl-main-daemon/Chart.yaml
@@ -1,7 +1,7 @@
-name: love-manager
+name: ospl-main-daemon
 apiVersion: v2
 version: 0.1.0
 dependencies:
-- name: love-manager
-  version: 0.3.1
+- name: ospl-main-daemon
+  version: 0.1.4
   repository: https://lsst-ts.github.io/charts/

--- a/apps/ospl-main-daemon/values-tucson-teststand.yaml
+++ b/apps/ospl-main-daemon/values-tucson-teststand.yaml
@@ -1,0 +1,16 @@
+ospl-main-daemon:
+  image:
+    repository: ts-dockerhub.lsst.org/ospl-daemon
+    tag: c0023
+    pullPolicy: Always
+  imagePullSecrets:
+  - name: ospl-daemon-nexus3-docker
+  env:
+    LSST_DDS_PARTITION_PREFIX: tucson
+    LSST_DDS_INTERFACE: net1
+  annotations:
+    k8s.v1.cni.cncf.io/networks: kube-system/misc-dds
+  initContainer:
+    repository: lsstit/ddsnet4u
+    tag: latest
+    pullPolicy: Always

--- a/apps/ospl-main-daemon/values.yaml
+++ b/apps/ospl-main-daemon/values.yaml
@@ -1,0 +1,12 @@
+ospl-main-daemon:
+  namespace: ospl-daemon
+  env:
+    OSPL_URI: file:///opt/lsst/software/stack/miniconda/lib/python3.8/config/ospl-shmem.xml
+    OSPL_INFOFILE: /tmp/ospl-info-daemon.log
+    OSPL_ERRORFILE: /tmp/ospl-error-daemon.log
+    OSPL_MASTER_PRIORITY: 201
+    LSST_DDSI2_SERVICE_TRACING_VERBOSITY: finer
+    LSST_ENABLE_DURABILITY_SERVICE_TRACING: "TRUE"
+    LSST_DDS_RESPONSIVENESS_TIMEOUT: 15s
+    LSST_DDS_ALIGNEE: Initial
+    LSST_DDS_ALIGNER: true

--- a/apps/test-csc/values-tucson-teststand.yaml
+++ b/apps/test-csc/values-tucson-teststand.yaml
@@ -1,0 +1,10 @@
+csc:
+  image:
+    repository: ts-dockerhub.lsst.org/test
+    tag: c0023
+    pullPolicy: Always
+    nexus3: nexus3-docker
+  env:
+    LSST_DDS_PARTITION_PREFIX: tucson
+  osplVersion: V6.10.4
+  shmemDir: /run/ospl

--- a/apps/watcher/values-tucson-teststand.yaml
+++ b/apps/watcher/values-tucson-teststand.yaml
@@ -1,0 +1,11 @@
+csc:
+  image:
+    repository: ts-dockerhub.lsst.org/watcher
+    tag: c0023
+    pullPolicy: Always
+    nexus3: nexus3-docker
+  env:
+    RUN_ARG: --state enabled --settings tucson
+    LSST_DDS_PARTITION_PREFIX: tucson
+  shmemDir: /run/ospl
+  osplVersion: V6.10.4

--- a/apps/weatherstation/values-tucson-teststand.yaml
+++ b/apps/weatherstation/values-tucson-teststand.yaml
@@ -1,0 +1,12 @@
+csc:
+  image:
+    repository: ts-dockerhub.lsst.org/weatherstation
+    tag: c0023
+    pullPolicy: Always
+    nexus3: nexus3-docker
+  env:
+    LSST_DDS_PARTITION_PREFIX: tucson
+  shmemDir: /run/ospl
+  osplVersion: V6.10.4
+ingress:
+  use: false


### PR DESCRIPTION
* Setup base configurations.
* Add auxtel configurations.
* Add obssys configurations.
* Add maintel configurations.
* Add EAS configurations.
* Block uws secrets for now.
* Remove uws from ospl-config for now.
* Update to cycle 21.
* Forgot to add init container.
* Change chart version for ospl-daemon.
* Fix annotation.
* Move ospl-daemons to only misc-dds.
* Add OSPL main daemon app.
* Update cluster-config info for TTS.
* Update to cycle 22.
* Try startup probe for kafka-producers.
* Change timing for kafka-producer startup probe.
* Update kafka-producer chart version.
* Auto-enable scriptqueues.
* Switch ospl-main-daemon to new Helm chart.
* Remove ScriptQueue partitions for now.
* Add test CSC configuration.
* Add dds-test namespace to ospl-config.
* Try different startup probe parameters for kafka-producers.
* Add HS CSCs to configuration.
* Quiet app of app.
* Add NFS mounts for ScriptQueues and MTAOS.
* Add LOVE config.
* Update love-manager chart version.
* Update love-nginx chart version and config.
* Update NTS config.
* Try another NGINX config.
* Update HS S3 instances.
* Add lfa secrets to cluster config.
* Try another NGINX config.
* Add docker pull secret to uws namespace.
* Add OCPS apps.
* Try direct path for LOVE access.
* Move to cycle 23
  * Update to cycle 23.
  * Add MTM2 to maintel.
  * Add WeatherStation and DIMM simulators.
  * Expand eas kafka-producer for new CSCs.
  * Expand LOVE producers.
  * Fix LOVE collector app target.
* Turn on autoenable for Watcher.
* Add obssys for LFA creds.
* Update ospl-config to add uws.
* Update scheduler configuration.
* Specify specific MTMount revision tag.
* Remove ingress config from MTMount.
* Target dmocps app to ticket branch.
* Update HS versions.