### PR TITLE
TTS: tickets/DM-33644

### DIFF
--- a/apps/love-manager/Chart.yaml
+++ b/apps/love-manager/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 version: 0.1.0
 dependencies:
 - name: love-manager
-  version: 0.3.1
+  version: 0.5.1
   repository: https://lsst-ts.github.io/charts/

--- a/apps/love-manager/values-tucson-teststand.yaml
+++ b/apps/love-manager/values-tucson-teststand.yaml
@@ -9,9 +9,26 @@ love-manager:
     SERVER_URL: love.tu.lsst.org
     REDIS_CONFIG_EXPIRY: 5
     REDIS_CONFIG_CAPACITY: 5000
+    LOVE_SITE: tucson
+  envSecrets:
+    AUTHLIST_USER_PASS: manager-authlist-user-password
   autoscaling:
-    enabled: false
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 15
     targetCPUUtilizationPercentage: 50
+  resources:
+    requests:
+      cpu: 250m
+      memory: 100Mi
+    limits:
+      cpu: 750m
+      memory: 300Mi
+  readinessProbe:
+    tcpSocket:
+      port: 8000
+    initialDelaySeconds: 20
+    periodSeconds: 10
   database:
     image:
       repository: postgres
@@ -28,3 +45,11 @@ love-manager:
       repository: redis
       tag: 5.0.3
       pullPolicy: IfNotPresent
+  viewBackup:
+    enabled: true
+    image:
+      repository: ts-dockerhub.lsst.org/love-view-backup
+      tag: develop
+      pullPolicy: Always
+      nexus3: nexus3-docker
+    schedule: "0 12 * * *"

--- a/apps/love-producer/values-tucson-teststand.yaml
+++ b/apps/love-producer/values-tucson-teststand.yaml
@@ -37,6 +37,7 @@ love-producer:
     mtaos: MTAOS:0
     mtdome: MTDome:0
     mtdometrajectory: MTDomeTrajectory:0
+    mtm1m3: MTM1M3:0
     mtm2: MTM2:0
     mtmount: MTMount:0
     mtptg: MTPtg:0

--- a/apps/love/values-tucson-teststand.yaml
+++ b/apps/love/values-tucson-teststand.yaml
@@ -1,1 +1,4 @@
 env: tucson-teststand
+spec:
+  source:
+    targetRevision: tickets/DM-33644


### PR DESCRIPTION
Improvements for LOVE app.

* Change LOVE app target revision.
* Add authlist user secret.
* Enable MTM1M3 producer.
* Enable HPA for manager.
* Add resource requests.
* Trying different resouce approach.
* Turn HPA off again.
* Try a TCP readiness probe for love-manager.
* Add resource limit and change readiness probe initial delay.
* Turn HPA on again.
* Add LOVE_SITE envvar.
* Turn on view backup.
* Update love-manager chart version.
* Change view backup job schedule to once a day.