### PR TITLE
TTS: Cycle 25 upgrade

### DIFF
--- a/apps/ataos/values-tucson-teststand.yaml
+++ b/apps/ataos/values-tucson-teststand.yaml
@@ -1,10 +1,11 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/ataos
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: tucson
+    LSST_SITE: tucson
   shmemDir: /run/ospl
   osplVersion: V6.10.4

--- a/apps/atdome/values-tucson-teststand.yaml
+++ b/apps/atdome/values-tucson-teststand.yaml
@@ -1,11 +1,12 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/atdome
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: tucson
+    LSST_SITE: tucson
     RUN_ARG: --simulate
   shmemDir: /run/ospl
   osplVersion: V6.10.4

--- a/apps/atdometrajectory/values-tucson-teststand.yaml
+++ b/apps/atdometrajectory/values-tucson-teststand.yaml
@@ -1,10 +1,11 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/atdometrajectory
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: tucson
+    LSST_SITE: tucson
   shmemDir: /run/ospl
   osplVersion: V6.10.4

--- a/apps/atheaderservice/values-tucson-teststand.yaml
+++ b/apps/atheaderservice/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/headerservice
-    tag: ts-v2.9.5_c0024
+    tag: ts-v3.0.0_c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/athexapod/values-tucson-teststand.yaml
+++ b/apps/athexapod/values-tucson-teststand.yaml
@@ -1,10 +1,11 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/athexapod
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: tucson
+    LSST_SITE: tucson
   shmemDir: /run/ospl
   osplVersion: V6.10.4

--- a/apps/atmcs/values-tucson-teststand.yaml
+++ b/apps/atmcs/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/atmcs_sim
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/atocps/values-tucson-teststand.yaml
+++ b/apps/atocps/values-tucson-teststand.yaml
@@ -1,10 +1,11 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/dmocps
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: tucson
+    LSST_SITE: tucson
   shmemDir: /run/ospl
   osplVersion: V6.10.4

--- a/apps/atpneumatics/values-tucson-teststand.yaml
+++ b/apps/atpneumatics/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/at_pneumatics_sim
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/atptg/values-tucson-teststand.yaml
+++ b/apps/atptg/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/ptkernel
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/atqueue/values-tucson-teststand.yaml
+++ b/apps/atqueue/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/scriptqueue
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/atscheduler/values-tucson-teststand.yaml
+++ b/apps/atscheduler/values-tucson-teststand.yaml
@@ -1,11 +1,12 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/scheduler
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: tucson
+    LSST_SITE: tucson
     S3_ENDPOINT_URL: https://s3.tu.lsst.org
   envSecrets:
   - name: AWS_ACCESS_KEY_ID

--- a/apps/atspectrograph/values-tucson-teststand.yaml
+++ b/apps/atspectrograph/values-tucson-teststand.yaml
@@ -1,11 +1,12 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/atspec
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: tucson
+    LSST_SITE: tucson
     RUN_ARG: --simulate
   shmemDir: /run/ospl
   osplVersion: V6.10.4

--- a/apps/ccheaderservice/values-tucson-teststand.yaml
+++ b/apps/ccheaderservice/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/headerservice
-    tag: ts-v2.9.5_c0024
+    tag: ts-v3.0.0_c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/ccocps/values-tucson-teststand.yaml
+++ b/apps/ccocps/values-tucson-teststand.yaml
@@ -1,10 +1,11 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/dmocps
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: tucson
+    LSST_SITE: tucson
   shmemDir: /run/ospl
   osplVersion: V6.10.4

--- a/apps/dimm/values-tucson-teststand.yaml
+++ b/apps/dimm/values-tucson-teststand.yaml
@@ -1,10 +1,11 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/dimm
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: tucson
+    LSST_SITE: tucson
   shmemDir: /run/ospl
   osplVersion: V6.10.4

--- a/apps/dsm/values-tucson-teststand.yaml
+++ b/apps/dsm/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/dsm
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/kafka-producers/values-tucson-teststand.yaml
+++ b/apps/kafka-producers/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 kafka-producers:
   image:
     repository: ts-dockerhub.lsst.org/salkafka
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
@@ -18,10 +18,7 @@ kafka-producers:
   shmemDir: /run/ospl
   producers:
     eas:
-      cscs: >-
-        DIMM
-        DSM
-        WeatherStation
+      cscs: DIMM DSM WeatherStation
   osplVersion: V6.10.4
   startupProbe:
     use: true

--- a/apps/love-commander/values-tucson-teststand.yaml
+++ b/apps/love-commander/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/love-commander
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/love-manager/values-tucson-teststand.yaml
+++ b/apps/love-manager/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 love-manager:
   image:
     repository: ts-dockerhub.lsst.org/love-manager
-    tag: c0024
+    tag: c0025
     pullPolicy: IfNotPresent
     nexus3: nexus3-docker
   secret_path: tucson-teststand.lsst.codes
@@ -49,7 +49,7 @@ love-manager:
     enabled: true
     image:
       repository: ts-dockerhub.lsst.org/love-view-backup
-      tag: develop
+      tag: c0025
       pullPolicy: Always
       nexus3: nexus3-docker
-    schedule: "0 12 * * *"
+    schedule: 0 12 * * *

--- a/apps/love-nginx/values-tucson-teststand.yaml
+++ b/apps/love-nginx/values-tucson-teststand.yaml
@@ -13,11 +13,11 @@ love-nginx:
     frontend:
       image:
         repository: ts-dockerhub.lsst.org/love-frontend
-        tag: c0024
+        tag: c0025
     manager:
       image:
         repository: ts-dockerhub.lsst.org/love-manager-static
-        tag: c0024
+        tag: c0025
       command:
       - /bin/sh
       - -c

--- a/apps/love-producer/values-tucson-teststand.yaml
+++ b/apps/love-producer/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 love-producer:
   image:
     repository: ts-dockerhub.lsst.org/love-producer
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
@@ -10,7 +10,6 @@ love-producer:
   shmemDir: /run/ospl
   producers:
     ataos: ATAOS:0
-    atarchiver: ATArchiver:0
     atcamera: ATCamera:0
     atdome: ATDome:0
     atdometrajectory: ATDomeTrajectory:0
@@ -19,15 +18,16 @@ love-producer:
     atmcs: ATMCS:0
     atpneumatics: ATPneumatics:0
     atocps: OCPS:1
+    atoods: ATOODS:0
     atptg: ATPtg:0
     atscheduler: Scheduler:2
     atscriptqueue: ScriptQueue:2
     atspectrograph: ATSpectrograph:0
     camerahexapod: MTHexapod:1
-    ccarchiver: CCArchiver:0
     cccamera: CCCamera:0
     ccheaderservice: CCHeaderService:0
     ccocps: OCPS:2
+    ccoods: CCOODS:0
     dimm1: DIMM:1
     dimm2: DIMM:2
     dsm1: DSM:1

--- a/apps/mtaos/values-tucson-teststand.yaml
+++ b/apps/mtaos/values-tucson-teststand.yaml
@@ -1,11 +1,12 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/mtaos
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: tucson
+    LSST_SITE: tucson
   shmemDir: /run/ospl
   osplVersion: V6.10.4
   nfsMountpoint:

--- a/apps/mtcamhexapod/values-tucson-teststand.yaml
+++ b/apps/mtcamhexapod/values-tucson-teststand.yaml
@@ -1,11 +1,12 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/mthexapod
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: tucson
+    LSST_SITE: tucson
     RUN_ARG: --simulate 1
   shmemDir: /run/ospl
   osplVersion: V6.10.4

--- a/apps/mtdome/values-tucson-teststand.yaml
+++ b/apps/mtdome/values-tucson-teststand.yaml
@@ -1,11 +1,12 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/mtdome
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: tucson
+    LSST_SITE: tucson
     RUN_ARG: --simulate
   shmemDir: /run/ospl
   osplVersion: V6.10.4

--- a/apps/mtdometrajectory/values-tucson-teststand.yaml
+++ b/apps/mtdometrajectory/values-tucson-teststand.yaml
@@ -1,10 +1,11 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/mtdometrajectory
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: tucson
+    LSST_SITE: tucson
   shmemDir: /run/ospl
   osplVersion: V6.10.4

--- a/apps/mtm2/values-tucson-teststand.yaml
+++ b/apps/mtm2/values-tucson-teststand.yaml
@@ -1,11 +1,12 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/m2
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: tucson
+    LSST_SITE: tucson
     RUN_ARG: --simulate
   shmemDir: /run/ospl
   osplVersion: V6.10.4

--- a/apps/mtm2hexapod/values-tucson-teststand.yaml
+++ b/apps/mtm2hexapod/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/mthexapod
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/mtmount/values-tucson-teststand.yaml
+++ b/apps/mtmount/values-tucson-teststand.yaml
@@ -1,11 +1,12 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/mtmount
-    tag: c0024.000
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: tucson
+    LSST_SITE: tucson
     RUN_ARG: --simulate
   shmemDir: /run/ospl
   osplVersion: V6.10.4

--- a/apps/mtptg/values-tucson-teststand.yaml
+++ b/apps/mtptg/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/ptkernel
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/mtqueue/values-tucson-teststand.yaml
+++ b/apps/mtqueue/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/scriptqueue
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/mtrotator/values-tucson-teststand.yaml
+++ b/apps/mtrotator/values-tucson-teststand.yaml
@@ -1,11 +1,12 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/mtrotator
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: tucson
+    LSST_SITE: tucson
     RUN_ARG: --simulate
   shmemDir: /run/ospl
   osplVersion: V6.10.4

--- a/apps/mtscheduler/values-tucson-teststand.yaml
+++ b/apps/mtscheduler/values-tucson-teststand.yaml
@@ -1,11 +1,12 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/scheduler
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: tucson
+    LSST_SITE: tucson
     S3_ENDPOINT_URL: https://s3.tu.lsst.org
   envSecrets:
   - name: AWS_ACCESS_KEY_ID

--- a/apps/ospl-daemon/values-tucson-teststand.yaml
+++ b/apps/ospl-daemon/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 ospl-daemon:
   image:
     repository: ts-dockerhub.lsst.org/ospl-daemon
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/ospl-main-daemon/values-tucson-teststand.yaml
+++ b/apps/ospl-main-daemon/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 ospl-main-daemon:
   image:
     repository: ts-dockerhub.lsst.org/ospl-daemon
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
   imagePullSecrets:
   - name: ospl-daemon-nexus3-docker

--- a/apps/test-csc/values-tucson-teststand.yaml
+++ b/apps/test-csc/values-tucson-teststand.yaml
@@ -1,10 +1,11 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/test
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: tucson
+    LSST_SITE: tucson
   osplVersion: V6.10.4
   shmemDir: /run/ospl

--- a/apps/watcher/values-tucson-teststand.yaml
+++ b/apps/watcher/values-tucson-teststand.yaml
@@ -1,11 +1,12 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/watcher
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
-    RUN_ARG: --state enabled --settings tucson
+    RUN_ARG: --state enabled --override tucson
     LSST_DDS_PARTITION_PREFIX: tucson
+    LSST_SITE: tucson
   shmemDir: /run/ospl
   osplVersion: V6.10.4

--- a/apps/weatherstation/values-tucson-teststand.yaml
+++ b/apps/weatherstation/values-tucson-teststand.yaml
@@ -1,11 +1,12 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/weatherstation
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: tucson
+    LSST_SITE: tucson
   shmemDir: /run/ospl
   osplVersion: V6.10.4
 ingress:


### PR DESCRIPTION
* Update to cycle 25.
* Remove archiver LOVE producers and add OODS ones.
* Add LSST_SITE envvar to configurable CSCs.
* Update Watcher CLI parameter for configuration rewrite.
* Update headerservice version.