### PR TITLE
Summit: Cycle 25 Upgrade

### DIFF
--- a/apps/adamsensors/values-summit.yaml
+++ b/apps/adamsensors/values-summit.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/adam-sensors
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/atdome/values-summit.yaml
+++ b/apps/atdome/values-summit.yaml
@@ -1,10 +1,11 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/atdome
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: summit
+    LSST_SITE: summit
   shmemDir: /run/ospl
   osplVersion: V6.10.4

--- a/apps/atdometrajectory/values-summit.yaml
+++ b/apps/atdometrajectory/values-summit.yaml
@@ -1,10 +1,11 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/atdometrajectory
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: summit
+    LSST_SITE: summit
   shmemDir: /run/ospl
   osplVersion: V6.10.4

--- a/apps/atheaderservice/values-summit.yaml
+++ b/apps/atheaderservice/values-summit.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/headerservice
-    tag: ts-v2.9.5_c0024
+    tag: ts-v3.0.1_c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/athexapod/values-summit.yaml
+++ b/apps/athexapod/values-summit.yaml
@@ -1,11 +1,12 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/athexapod
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: summit
+    LSST_SITE: summit
   shmemDir: /run/ospl
   annotations:
     k8s.v1.cni.cncf.io/networks: kube-system/macvlan-conf

--- a/apps/atocps/values-summit.yaml
+++ b/apps/atocps/values-summit.yaml
@@ -1,10 +1,11 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/dmocps
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: summit
+    LSST_SITE: summit
   shmemDir: /run/ospl
   osplVersion: V6.10.4

--- a/apps/atptg/values-summit.yaml
+++ b/apps/atptg/values-summit.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/ptkernel
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/atqueue/values-summit.yaml
+++ b/apps/atqueue/values-summit.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/scriptqueue
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/atscheduler/values-summit.yaml
+++ b/apps/atscheduler/values-summit.yaml
@@ -1,11 +1,12 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/scheduler
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: summit
+    LSST_SITE: summit
     S3_ENDPOINT_URL: https://s3.cp.lsst.org
   envSecrets:
   - name: AWS_ACCESS_KEY_ID

--- a/apps/atspectrograph/values-summit.yaml
+++ b/apps/atspectrograph/values-summit.yaml
@@ -1,10 +1,11 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/atspec
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: summit
+    LSST_SITE: summit
   shmemDir: /run/ospl
   osplVersion: V6.10.4

--- a/apps/ccheaderservice/values-summit.yaml
+++ b/apps/ccheaderservice/values-summit.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/headerservice
-    tag: ts-v2.9.5_c0024
+    tag: ts-v3.0.1_c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/ccocps/values-summit.yaml
+++ b/apps/ccocps/values-summit.yaml
@@ -1,10 +1,11 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/dmocps
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: summit
+    LSST_SITE: summit
   shmemDir: /run/ospl
   osplVersion: V6.10.4

--- a/apps/dimm/values-summit.yaml
+++ b/apps/dimm/values-summit.yaml
@@ -1,10 +1,11 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/dimm
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: summit
+    LSST_SITE: summit
   shmemDir: /run/ospl
   osplVersion: V6.10.4

--- a/apps/eas/values-summit.yaml
+++ b/apps/eas/values-summit.yaml
@@ -1,8 +1,6 @@
 env: summit
 cscs:
-  - adamsensors
   - dimm1
-  - dimm2
   - hvac
   - ess1
   - ess101
@@ -10,7 +8,7 @@ cscs:
   - ess103
   - ess201
 renameMap:
-  ess1: comcam-ess01
+  ess1: camhexrot-ess01
   ess101: mtdome-ess01
   ess102: mtdome-ess02
   ess103: mtdome-ess03

--- a/apps/electrometer/values-summit.yaml
+++ b/apps/electrometer/values-summit.yaml
@@ -1,11 +1,12 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/electrometer
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: summit
+    LSST_SITE: summit
     S3_ENDPOINT_URL: https://s3.cp.lsst.org
   envSecrets:
   - name: AWS_ACCESS_KEY_ID

--- a/apps/ess/values-ess1.yaml
+++ b/apps/ess/values-ess1.yaml
@@ -1,5 +1,5 @@
 csc:
   env:
-    OSPL_INFOFILE: /tmp/ospl-info-comcam-ess01.log
-    OSPL_ERRORFILE: /tmp/ospl-error-comcam-ess01.log
+    OSPL_INFOFILE: /tmp/ospl-info-camhexrot-ess01.log
+    OSPL_ERRORFILE: /tmp/ospl-error-camhexrot-ess01.log
     RUN_ARG: 1

--- a/apps/ess/values-summit.yaml
+++ b/apps/ess/values-summit.yaml
@@ -1,10 +1,11 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/ess
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: summit
+    LSST_SITE: summit
   shmemDir: /run/ospl
   osplVersion: V6.10.4

--- a/apps/hvac/values-summit.yaml
+++ b/apps/hvac/values-summit.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/hvac
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/kafka-producers/values-summit.yaml
+++ b/apps/kafka-producers/values-summit.yaml
@@ -1,7 +1,7 @@
 kafka-producers:
   image:
     repository: ts-dockerhub.lsst.org/salkafka
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
@@ -21,3 +21,8 @@ kafka-producers:
     vms: null
     m1m3ts:
       cscs: MTM1M3TS
+  startupProbe:
+    use: true
+    failureThreshold: 15
+    initialDelay: 20
+    period: 10

--- a/apps/kafka-producers/values-tucson-teststand.yaml
+++ b/apps/kafka-producers/values-tucson-teststand.yaml
@@ -19,8 +19,6 @@ kafka-producers:
   producers:
     eas:
       cscs: DIMM DSM WeatherStation
-    mtaircompressor:
-      cscs: MTAirCompressor
   osplVersion: V6.10.4
   startupProbe:
     use: true

--- a/apps/kafka-producers/values.yaml
+++ b/apps/kafka-producers/values.yaml
@@ -84,3 +84,5 @@ kafka-producers:
         FiberSpectrograph
         LinearStage
         TunableLaser
+    mtaircompressor:
+      cscs: MTAirCompressor

--- a/apps/maintel/values-summit.yaml
+++ b/apps/maintel/values-summit.yaml
@@ -10,5 +10,7 @@ cscs:
   - ccheaderservice
   - mtcamhexapod
   - mtm2hexapod
+  - mtaircompressor1
+  - mtaircompressor2
 isSim:
   - mtdome

--- a/apps/mtaircompressor/values-mtaircompressor1.yaml
+++ b/apps/mtaircompressor/values-mtaircompressor1.yaml
@@ -1,0 +1,3 @@
+csc:
+  env:
+    RUN_ARG: 1

--- a/apps/mtaircompressor/values-mtaircompressor2.yaml
+++ b/apps/mtaircompressor/values-mtaircompressor2.yaml
@@ -1,0 +1,3 @@
+csc:
+  env:
+    RUN_ARG: 2

--- a/apps/mtaircompressor/values-summit.yaml
+++ b/apps/mtaircompressor/values-summit.yaml
@@ -1,11 +1,10 @@
 csc:
   image:
-    repository: ts-dockerhub.lsst.org/ataos
+    repository: ts-dockerhub.lsst.org/mtaircompressor
     tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: summit
-    LSST_SITE: summit
   shmemDir: /run/ospl
   osplVersion: V6.10.4

--- a/apps/mtaos/values-summit.yaml
+++ b/apps/mtaos/values-summit.yaml
@@ -1,11 +1,12 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/mtaos
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: summit
+    LSST_SITE: summit
   shmemDir: /run/ospl
   nfsMountpoint:
   - name: comcam-gen3-data

--- a/apps/mtcamhexapod/values-summit-sim.yaml
+++ b/apps/mtcamhexapod/values-summit-sim.yaml
@@ -1,5 +1,5 @@
 csc:
   image:
-    tag: c0024
+    tag: c0025
   env:
     RUN_ARG: --simulate 1

--- a/apps/mtcamhexapod/values-summit.yaml
+++ b/apps/mtcamhexapod/values-summit.yaml
@@ -1,11 +1,12 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/mthexapod
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: summit
+    LSST_SITE: summit
     RUN_ARG: 1
   shmemDir: /run/ospl
   osplVersion: V6.10.4

--- a/apps/mtdome/values-summit.yaml
+++ b/apps/mtdome/values-summit.yaml
@@ -1,11 +1,12 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/mtdome
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: summit
+    LSST_SITE: summit
     RUN_ARG: --simulate
   shmemDir: /run/ospl
   osplVersion: V6.10.4

--- a/apps/mtdometrajectory/values-summit.yaml
+++ b/apps/mtdometrajectory/values-summit.yaml
@@ -1,10 +1,11 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/mtdometrajectory
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: summit
+    LSST_SITE: summit
   shmemDir: /run/ospl
   osplVersion: V6.10.4

--- a/apps/mtm1m3/values-summit-sim.yaml
+++ b/apps/mtm1m3/values-summit-sim.yaml
@@ -1,11 +1,12 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/mtm1m3_sim
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: summit
+    LSST_SITE: summit
     OSPL_RELEASE: v6.10.4
   shmemDir: /run/ospl
   osplVersion: V6.10.4

--- a/apps/mtm2/values-summit-sim.yaml
+++ b/apps/mtm2/values-summit-sim.yaml
@@ -1,11 +1,12 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/m2
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: summit
+    LSST_SITE: summit
     RUN_ARG: --simulate
   shmemDir: /run/ospl
   osplVersion: V6.10.4

--- a/apps/mtm2/values-summit.yaml
+++ b/apps/mtm2/values-summit.yaml
@@ -1,10 +1,11 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/m2
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: summit
+    LSST_SITE: summit
   shmemDir: /run/ospl
   osplVersion: V6.10.4

--- a/apps/mtm2hexapod/values-summit-sim.yaml
+++ b/apps/mtm2hexapod/values-summit-sim.yaml
@@ -1,5 +1,5 @@
 csc:
   image:
-    tag: c0024
+    tag: c0025
   env:
     RUN_ARG: --simulate 2

--- a/apps/mtm2hexapod/values-summit.yaml
+++ b/apps/mtm2hexapod/values-summit.yaml
@@ -1,11 +1,12 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/mthexapod
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: summit
+    LSST_SITE: summit
     RUN_ARG: 2
   shmemDir: /run/ospl
   osplVersion: V6.10.4

--- a/apps/mtmount/values-summit-sim.yaml
+++ b/apps/mtmount/values-summit-sim.yaml
@@ -1,5 +1,5 @@
 csc:
   image:
-    tag: c0024.000
+    tag: c0025
   env:
     RUN_ARG: --simulate

--- a/apps/mtmount/values-summit.yaml
+++ b/apps/mtmount/values-summit.yaml
@@ -1,10 +1,11 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/mtmount
-    tag: c0024.009
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: summit
+    LSST_SITE: summit
   shmemDir: /run/ospl
   osplVersion: V6.10.4

--- a/apps/mtptg/values-summit.yaml
+++ b/apps/mtptg/values-summit.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/ptkernel
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/mtqueue/values-summit.yaml
+++ b/apps/mtqueue/values-summit.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/scriptqueue
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/mtrotator/values-summit-sim.yaml
+++ b/apps/mtrotator/values-summit-sim.yaml
@@ -1,5 +1,5 @@
 csc:
   image:
-    tag: c0024
+    tag: c0025
   env:
     RUN_ARG: --simulate

--- a/apps/mtrotator/values-summit.yaml
+++ b/apps/mtrotator/values-summit.yaml
@@ -1,10 +1,11 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/mtrotator
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: summit
+    LSST_SITE: summit
   shmemDir: /run/ospl
   osplVersion: V6.10.4

--- a/apps/mtscheduler/values-summit.yaml
+++ b/apps/mtscheduler/values-summit.yaml
@@ -1,11 +1,12 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/scheduler
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: summit
+    LSST_SITE: summit
     S3_ENDPOINT_URL: https://s3.cp.lsst.org
   envSecrets:
   - name: AWS_ACCESS_KEY_ID

--- a/apps/ocps/values-summit.yaml
+++ b/apps/ocps/values-summit.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/dmocps
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/ospl-daemon/values-summit.yaml
+++ b/apps/ospl-daemon/values-summit.yaml
@@ -1,7 +1,7 @@
 ospl-daemon:
   image:
     repository: ts-dockerhub.lsst.org/ospl-daemon
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/test-csc/values-summit.yaml
+++ b/apps/test-csc/values-summit.yaml
@@ -1,10 +1,11 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/test
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: summit
+    LSST_SITE: summit
   osplVersion: V6.10.4
   shmemDir: /run/ospl

--- a/apps/watcher/values-summit.yaml
+++ b/apps/watcher/values-summit.yaml
@@ -1,11 +1,12 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/watcher
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
-    RUN_ARG: --state enabled --settings summit
+    RUN_ARG: --state enabled
     LSST_DDS_PARTITION_PREFIX: summit
+    LSST_SITE: summit
   shmemDir: /run/ospl
   osplVersion: V6.10.4

--- a/apps/weatherstation/values-summit.yaml
+++ b/apps/weatherstation/values-summit.yaml
@@ -1,11 +1,12 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/weatherstation
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
     nexus3: nexus3-docker
   env:
     LSST_DDS_PARTITION_PREFIX: summit
+    LSST_SITE: summit
   shmemDir: /run/ospl
   osplVersion: V6.10.4
 ingress:

--- a/services/rubintv-broadcaster/values-summit.yaml
+++ b/services/rubintv-broadcaster/values-summit.yaml
@@ -1,7 +1,7 @@
 rubintv-broadcaster:
   image:
     repository: ts-dockerhub.lsst.org/rubintv-broadcaster
-    tag: c0024
+    tag: c0025
     pullPolicy: Always
   vaultPrefixPath: secret/k8s_operator/summit-lsp.lsst.codes
   pullSecretsPath: ts/software/nexus3-docker


### PR DESCRIPTION
* Update to Cycle 25 tag.
* Rename comcam ESS to camhexrot.
* Remove adamsensors from eas app.
* Remove dimm2 from eas app.
* Add startup probe to kafka-producers.
* Add mtaircompressor apps.
* Remove settings CLI option from watcher.
* Add LSST_SITE envvar for all configurable CSCs.