### PR TITLE
TTS: Upgrade to Cycle 26.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
         run: brew install norwoodj/tap/helm-docs
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
 
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 

--- a/apps/ataos/values-tucson-teststand.yaml
+++ b/apps/ataos/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/ataos
-    tag: c0025
+    tag: c0026
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/atdome/values-tucson-teststand.yaml
+++ b/apps/atdome/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/atdome
-    tag: c0025
+    tag: c0026
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/atdometrajectory/values-tucson-teststand.yaml
+++ b/apps/atdometrajectory/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/atdometrajectory
-    tag: c0025
+    tag: c0026
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/atheaderservice/values-tucson-teststand.yaml
+++ b/apps/atheaderservice/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/headerservice
-    tag: ts-v3.0.2_c0025
+    tag: c0026
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/athexapod/values-tucson-teststand.yaml
+++ b/apps/athexapod/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/athexapod
-    tag: c0025
+    tag: c0026
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/atmcs/values-tucson-teststand.yaml
+++ b/apps/atmcs/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/atmcs_sim
-    tag: c0025
+    tag: c0026
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/atocps/values-tucson-teststand.yaml
+++ b/apps/atocps/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/dmocps
-    tag: c0025
+    tag: c0026
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/atpneumatics/values-tucson-teststand.yaml
+++ b/apps/atpneumatics/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/at_pneumatics_sim
-    tag: c0025
+    tag: c0026
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/atptg/values-tucson-teststand.yaml
+++ b/apps/atptg/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/ptkernel
-    tag: c0025
+    tag: c0026
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/atqueue/values-tucson-teststand.yaml
+++ b/apps/atqueue/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/scriptqueue
-    tag: c0025
+    tag: c0026
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/atscheduler/values-tucson-teststand.yaml
+++ b/apps/atscheduler/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/scheduler
-    tag: c0025
+    tag: c0026
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/atspectrograph/values-tucson-teststand.yaml
+++ b/apps/atspectrograph/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/atspec
-    tag: c0025
+    tag: c0026
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/authorize/values-tucson-teststand.yaml
+++ b/apps/authorize/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/authorize
-    tag: c0025
+    tag: c0026
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/ccheaderservice/values-tucson-teststand.yaml
+++ b/apps/ccheaderservice/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/headerservice
-    tag: ts-v3.0.2_c0025
+    tag: c0026
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/ccocps/values-tucson-teststand.yaml
+++ b/apps/ccocps/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/dmocps
-    tag: c0025
+    tag: c0026
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/dimm/values-tucson-teststand.yaml
+++ b/apps/dimm/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/dimm
-    tag: c0025
+    tag: c0026
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/dsm/values-tucson-teststand.yaml
+++ b/apps/dsm/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/dsm
-    tag: c0025
+    tag: c0026
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/eas/values-tucson-teststand.yaml
+++ b/apps/eas/values-tucson-teststand.yaml
@@ -4,8 +4,10 @@ cscs:
   - dsm2
   - weatherstation1
   - dimm1
+  - dimm2
 isSim:
   - dsm1
   - dsm2
   - weatherstation1
   - dimm1
+  - dimm2

--- a/apps/kafka-producers/values-tucson-teststand.yaml
+++ b/apps/kafka-producers/values-tucson-teststand.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ts-dockerhub.lsst.org/salkafka
-  tag: c0025
+  tag: c0026
   pullPolicy: Always
   nexus3: nexus3-docker
 env:

--- a/apps/love-commander/values-tucson-teststand.yaml
+++ b/apps/love-commander/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/love-commander
-    tag: c0025
+    tag: c0026
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/love-manager/values-tucson-teststand.yaml
+++ b/apps/love-manager/values-tucson-teststand.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ts-dockerhub.lsst.org/love-manager
-  tag: c0025
+  tag: c0026
   pullPolicy: Always
   nexus3: nexus3-docker
 secret_path: tucson-teststand.lsst.codes
@@ -48,7 +48,7 @@ viewBackup:
   enabled: true
   image:
     repository: ts-dockerhub.lsst.org/love-view-backup
-    tag: c0025
+    tag: c0026
     pullPolicy: Always
     nexus3: nexus3-docker
   schedule: 0 12 * * *

--- a/apps/love-nginx/README.md
+++ b/apps/love-nginx/README.md
@@ -17,9 +17,11 @@ Helm chart for the LOVE Nginx server.
 | ingress.hostname | string | `"love.local"` | Hostname for the NGINX ingress |
 | ingress.httpPath | string | `"/"` | Path name associated with the NGINX ingress |
 | ingress.pathType | string | `""` | Set the Kubernetes path type for the NGINX ingress |
+| initContainers.frontend.image.pullPolicy | string | `"IfNotPresent"` | The pull policy to use for the frontend image |
 | initContainers.frontend.image.repository | string | `"lsstts/love-frontend"` | The frontend image to use |
 | initContainers.frontend.image.tag | string | `"develop"` | The tag to use for the frontend image |
 | initContainers.manager.command | list | `["/bin/sh","-c","mkdir -p /usr/src/love-manager/media/thumbnails; mkdir -p /usr/src/love-manager/media/configs; cp -Rv /usr/src/love/manager/static /usr/src/love-manager; cp -uv /usr/src/love/manager/ui_framework/fixtures/thumbnails/* /usr/src/love-manager/media/thumbnails; cp -uv /usr/src/love/manager/api/fixtures/configs/* /usr/src/love-manager/media/configs"]` | The command to execute for the love-manager static content |
+| initContainers.manager.image.pullPolicy | string | `"IfNotPresent"` | The pull policy to use for the love-manager static content image |
 | initContainers.manager.image.repository | string | `"lsstts/love-manager"` | The static love-manager content image to use |
 | initContainers.manager.image.tag | string | `"develop"` | The tag to use for the love-manager static content image |
 | namespace | string | `"love"` | The overall namespace for the application |

--- a/apps/love-nginx/templates/nginx-deployment.yaml
+++ b/apps/love-nginx/templates/nginx-deployment.yaml
@@ -22,14 +22,14 @@ spec:
       initContainers:
       - name: love-frontend
         image: "{{ .Values.initContainers.frontend.image.repository }}:{{ .Values.initContainers.frontend.image.tag }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        imagePullPolicy: {{ .Values.initContainers.frontend.image.pullPolicy }}
         command: ["/bin/sh", "-c", "cp -Rv /usr/src/love/ /usr/src/love-frontend"]
         volumeMounts:
           - mountPath: /usr/src
             name: {{ .Values.staticStore.name }}
       - name: love-manager-static
         image: "{{ .Values.initContainers.manager.image.repository }}:{{ .Values.initContainers.manager.image.tag }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        imagePullPolicy: {{ .Values.initContainers.manager.image.pullPolicy }}
         {{- with .Values.initContainers.manager.command }}
         command:
         {{- range $item := $.Values.initContainers.manager.command }}

--- a/apps/love-nginx/values-tucson-teststand.yaml
+++ b/apps/love-nginx/values-tucson-teststand.yaml
@@ -12,16 +12,18 @@ initContainers:
   frontend:
     image:
       repository: ts-dockerhub.lsst.org/love-frontend
-      tag: c0025
+      tag: c0026
+      pullPolicy: Always
   manager:
     image:
       repository: ts-dockerhub.lsst.org/love-manager-static
-      tag: c0025
+      tag: c0026
+      pullPolicy: Always
     command:
     - /bin/sh
     - -c
-    - 'cp -Rv /usr/src/love/manager/static /usr/src/love-manager; cp -Rv /usr/src/love/manager/media
-      /usr/src/love-manager'
+    - cp -Rv /usr/src/love/manager/static /usr/src/love-manager; cp -Rv /usr/src/love/manager/media
+      /usr/src/love-manager
 staticStore:
   name: love-nginx-static
   storageClass: rook-ceph-block

--- a/apps/love-nginx/values.yaml
+++ b/apps/love-nginx/values.yaml
@@ -60,12 +60,16 @@ initContainers:
       repository: lsstts/love-frontend
       # -- The tag to use for the frontend image
       tag: develop
+      # -- The pull policy to use for the frontend image
+      pullPolicy: IfNotPresent
   manager:
     image:
       # -- The static love-manager content image to use
       repository: lsstts/love-manager
       # -- The tag to use for the love-manager static content image
       tag: develop
+      # -- The pull policy to use for the love-manager static content image
+      pullPolicy: IfNotPresent
     # -- The command to execute for the love-manager static content
     command: ["/bin/sh", "-c", "mkdir -p /usr/src/love-manager/media/thumbnails; mkdir -p /usr/src/love-manager/media/configs; cp -Rv /usr/src/love/manager/static /usr/src/love-manager; cp -uv /usr/src/love/manager/ui_framework/fixtures/thumbnails/* /usr/src/love-manager/media/thumbnails; cp -uv /usr/src/love/manager/api/fixtures/configs/* /usr/src/love-manager/media/configs"]
 staticStore:

--- a/apps/love-producer/values-tucson-teststand.yaml
+++ b/apps/love-producer/values-tucson-teststand.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ts-dockerhub.lsst.org/love-producer
-  tag: c0025
+  tag: c0026
   pullPolicy: Always
   nexus3: nexus3-docker
 env:

--- a/apps/mtaircompressor/values-tucson-teststand.yaml
+++ b/apps/mtaircompressor/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/mtaircompressor
-    tag: c0025
+    tag: c0026
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/mtaos/values-tucson-teststand.yaml
+++ b/apps/mtaos/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/mtaos
-    tag: c0025
+    tag: c0026
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/mtcamhexapod/values-tucson-teststand.yaml
+++ b/apps/mtcamhexapod/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/mthexapod
-    tag: c0025
+    tag: c0026
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/mtdome/values-tucson-teststand.yaml
+++ b/apps/mtdome/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/mtdome
-    tag: c0025
+    tag: c0026
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/mtdometrajectory/values-tucson-teststand.yaml
+++ b/apps/mtdometrajectory/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/mtdometrajectory
-    tag: c0025
+    tag: c0026
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/mtm2/values-tucson-teststand.yaml
+++ b/apps/mtm2/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/m2
-    tag: c0025
+    tag: c0026
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/mtm2hexapod/values-tucson-teststand.yaml
+++ b/apps/mtm2hexapod/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/mthexapod
-    tag: c0025
+    tag: c0026
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/mtmount/values-tucson-teststand.yaml
+++ b/apps/mtmount/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/mtmount
-    tag: c0025.003
+    tag: c0026
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/mtptg/values-tucson-teststand.yaml
+++ b/apps/mtptg/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/ptkernel
-    tag: c0025
+    tag: c0026
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/mtqueue/values-tucson-teststand.yaml
+++ b/apps/mtqueue/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/scriptqueue
-    tag: c0025
+    tag: c0026
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/mtrotator/values-tucson-teststand.yaml
+++ b/apps/mtrotator/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/mtrotator
-    tag: c0025
+    tag: c0026
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/mtscheduler/values-tucson-teststand.yaml
+++ b/apps/mtscheduler/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/scheduler
-    tag: c0025
+    tag: c0026
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/ospl-config/Chart.yaml
+++ b/apps/ospl-config/Chart.yaml
@@ -1,4 +1,4 @@
 name: ospl-config
 apiVersion: v2
-version: 0.6.0
+version: 0.7.0
 description: Handle OSPL configuration.

--- a/apps/ospl-config/templates/_helpers.tpl
+++ b/apps/ospl-config/templates/_helpers.tpl
@@ -146,7 +146,9 @@ Create chart name and version as used by the chart label.
                     aligner="${LSST_DDS_ALIGNER:-false}"
                     durability="Durable"
                     masterPriority="${OSPL_MASTER_PRIORITY:-1}"
-                    nameSpace="defaultNamespace"/>
+                    nameSpace="defaultNamespace">
+                <Merge scope="*" type="${LSST_DDS_MERGE_POLICY:-Ignore}"/>
+            </Policy>
         </NameSpaces>
     </DurabilityService>
     <TunerService name="cmsoap">

--- a/apps/ospl-daemon/values-tucson-teststand.yaml
+++ b/apps/ospl-daemon/values-tucson-teststand.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ts-dockerhub.lsst.org/ospl-daemon
-  tag: c0025
+  tag: c0026
   pullPolicy: Always
   nexus3: nexus3-docker
 env:

--- a/apps/ospl-main-daemon/values-tucson-teststand.yaml
+++ b/apps/ospl-main-daemon/values-tucson-teststand.yaml
@@ -1,18 +1,18 @@
 image:
   repository: ts-dockerhub.lsst.org/ospl-daemon
-  tag: c0025
+  tag: c0026
   pullPolicy: Always
 imagePullSecrets:
 - name: ospl-daemon-nexus3-docker
 env:
   LSST_DDS_PARTITION_PREFIX: tucson
   LSST_DDS_INTERFACE: net1
-  OSPL_URI: file:///opt/lsst/software/stack/miniconda/lib/python3.8/config/ospl-shmem.xml
+  OSPL_URI: file:///opt/lsst/software/stack/miniconda/lib/python3.10/site-packages/lsst/ts/ddsconfig/data/config/ospl-shmem.xml
   OSPL_INFOFILE: /tmp/ospl-info-daemon.log
   OSPL_ERRORFILE: /tmp/ospl-error-daemon.log
   OSPL_MASTER_PRIORITY: 201
   LSST_DDSI2_SERVICE_TRACING_VERBOSITY: finer
-  LSST_ENABLE_DURABILITY_SERVICE_TRACING: "TRUE"
+  LSST_ENABLE_DURABILITY_SERVICE_TRACING: 'TRUE'
   LSST_DDS_RESPONSIVENESS_TIMEOUT: 15s
   LSST_DDS_ALIGNEE: Initial
   LSST_DDS_ALIGNER: true

--- a/apps/test-csc/values-tucson-teststand.yaml
+++ b/apps/test-csc/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/test
-    tag: c0025
+    tag: c0026
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/watcher/values-tucson-teststand.yaml
+++ b/apps/watcher/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/watcher
-    tag: c0025
+    tag: c0026
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/apps/weatherstation/values-tucson-teststand.yaml
+++ b/apps/weatherstation/values-tucson-teststand.yaml
@@ -1,7 +1,7 @@
 csc:
   image:
     repository: ts-dockerhub.lsst.org/weatherstation
-    tag: c0025
+    tag: c0026
     pullPolicy: Always
     nexus3: nexus3-docker
   env:

--- a/bin/requirements.txt
+++ b/bin/requirements.txt
@@ -1,1 +1,2 @@
 pyyaml
+ruamel.yaml

--- a/ct.yaml
+++ b/ct.yaml
@@ -4,6 +4,8 @@
 
 charts:
   - "apps/ospl-config"
+  - "apps/kafka-producers"
+  - "services/rubintv-broadcaster"
 check-version-increment: false
 target-branch: main
 validate-maintainers: false


### PR DESCRIPTION
* Update to cycle 26 tag.
* Use ruamel.yaml in update_parameter.py
* Add merge policy to ospl-config chart.
* Change OSPL_URI for main daemon.
* Add DIMM2 back to eas app.
* Separate pull policies for love-nginx init containers.
* Make update_parameter.py handle image tag updates better.
* Add more directories to chart linter.
* Add dependabot for action updates.
* Update workflows to setup-python v4.