### PR TITLE
[DM-35461] Add secret in kafka-producers for the ts-salkafka password

### DIFF
--- a/apps/cluster-config/values-tucson-teststand.yaml
+++ b/apps/cluster-config/values-tucson-teststand.yaml
@@ -13,3 +13,7 @@ secrets:
       - love
       - maintel
       - obssys
+  - name: ts-salkafka
+    key: ts-salkafka-password
+    namespaces:
+      - kafka-producers

--- a/apps/kafka-producers/Chart.yaml
+++ b/apps/kafka-producers/Chart.yaml
@@ -1,4 +1,4 @@
 name: kafka-producers
 apiVersion: v2
-version: 0.10.1
+version: 0.11.0
 description: A Helm chart for deploying the Kafka producers.

--- a/apps/kafka-producers/README.md
+++ b/apps/kafka-producers/README.md
@@ -8,15 +8,16 @@ A Helm chart for deploying the Kafka producers.
 |-----|------|---------|-------------|
 | affinity | object | `{}` | This specifies the scheduling constraints of the pod |
 | annotations | object | `{}` | This allows the specification of pod annotations |
-| env.brokerIp | string | `"kafka-0-tucson-teststand-efd.lsst.codes"` | The URI for the Kafka broker that received the generated Kafka messages |
-| env.brokerPort | int | `31090` | The port associated with the Kafka broker specified in brokerIp |
+| env.brokerIp | string | `"sasquatch-kafka-brokers.sasquatch"` | The URI for the Kafka broker that received the generated Kafka messages |
+| env.brokerPort | int | `9092` | The port associated with the Kafka broker specified in brokerIp |
 | env.extras | object | `{"OSPL_ERRORFILE":"/tmp/ospl-error-kafka-producers.log","OSPL_INFOFILE":"/tmp/ospl-info-kafka-producers.log"}` | A set of key,value pairs to specify extra environmental variables |
 | env.logLevel | int | `10` | This value determines the logging level for the producers |
 | env.lsstDdsPartitionPrefix | string | `"rubinobs"` | The LSST_DDS_PARTITION_PREFIX name applied to all producer containers |
 | env.partitions | int | `1` | The number of partitions that the producers are supporting |
-| env.registryAddr | string | `"https://schema-registry-tucson-teststand-efd.lsst.codes"` | The URL for the Kafka broker associated schema registry |
+| env.registryAddr | string | `"http://sasquatch-schema-registry.sasquatch:8081"` | The URL for the Kafka broker associated schema registry |
 | env.replication | int | `3` | The number of replications available to the producers |
 | env.waitAck | int | `1` | The number of Kafka brokers to wait for an ack from |
+| existingSecret | string | `"kafka-producers-ts-salkafka"` | This is the secret that contains the ts-salkafka password for authentication with the sasquatch Kafka broker |
 | image.nexus3 | string | `nil` | The tag name for the Nexus3 Docker repository secrets if private images need to be pulled |
 | image.pullPolicy | string | `"IfNotPresent"` | The policy to apply when pulling an image for deployment |
 | image.repository | string | `"lsstts/salkafka"` | The Docker registry name of the container image to use for the producers |

--- a/apps/kafka-producers/templates/deployment.yaml
+++ b/apps/kafka-producers/templates/deployment.yaml
@@ -86,6 +86,13 @@ spec:
               {{- else }}
               value: {{ $.Values.env.logLevel | quote }}
               {{- end }}
+            {{- if $.Values.existingSecret }}
+            - name: TS_SALKAFKA_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Values.existingSecret }}
+                  key: ts-salkafka-password
+            {{- end }}
             {{- if $.Values.env.extras }}
             {{- range $env_var, $env_value := $.Values.env.extras }}
             - name: {{ $env_var }}

--- a/apps/kafka-producers/values-summit.yaml
+++ b/apps/kafka-producers/values-summit.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ts-dockerhub.lsst.org/salkafka
-  tag: c0026
+  tag: c0026.000
   pullPolicy: Always
   nexus3: nexus3-docker
 env:

--- a/apps/kafka-producers/values-tucson-teststand.yaml
+++ b/apps/kafka-producers/values-tucson-teststand.yaml
@@ -5,15 +5,16 @@ image:
   nexus3: nexus3-docker
 env:
   lsstDdsPartitionPrefix: tucson
-  brokerIp: cp-helm-charts-cp-kafka-headless.cp-helm-charts
+  brokerIp: sasquatch-kafka-brokers.sasquatch
   brokerPort: 9092
-  registryAddr: http://cp-helm-charts-cp-schema-registry.cp-helm-charts:8081
+  registryAddr: http://sasquatch-schema-registry.sasquatch:8081
   partitions: 1
   replication: 3
   waitAck: 1
   logLevel: 20
   extras:
     LSST_DDS_RESPONSIVENESS_TIMEOUT: 15s
+    TS_SALKAFKA_USERNAME: ts-salkafka
 shmemDir: /run/ospl
 osplVersion: V6.10.4
 producers:
@@ -90,6 +91,7 @@ producers:
     cscs: DIMM DSM WeatherStation
   authorize:
     cscs: Authorize
+existingSecret: kafka-producers-ts-salkafka
 startupProbe:
   use: true
   failureThreshold: 15

--- a/apps/kafka-producers/values.yaml
+++ b/apps/kafka-producers/values.yaml
@@ -11,11 +11,11 @@ env:
   # -- The LSST_DDS_PARTITION_PREFIX name applied to all producer containers
   lsstDdsPartitionPrefix: rubinobs
   # -- The URI for the Kafka broker that received the generated Kafka messages
-  brokerIp: kafka-0-tucson-teststand-efd.lsst.codes
+  brokerIp: sasquatch-kafka-brokers.sasquatch
   # -- The port associated with the Kafka broker specified in brokerIp
-  brokerPort: 31090
+  brokerPort: 9092
   # -- The URL for the Kafka broker associated schema registry
-  registryAddr: https://schema-registry-tucson-teststand-efd.lsst.codes
+  registryAddr: http://sasquatch-schema-registry.sasquatch:8081
   # -- The number of Kafka brokers to wait for an ack from
   waitAck: 1
   # -- The number of partitions that the producers are supporting
@@ -48,6 +48,8 @@ shmemDir:
 useHostPid:
 # -- (bool) This sets the use of the host inter-process communication system. Defaults to true if not specified
 useHostIpc:
+# -- This is the secret that contains the ts-salkafka password for authentication with the sasquatch Kafka broker
+existingSecret: kafka-producers-ts-salkafka
 # -- This allows the specification of pod annotations
 annotations: {}
 startupProbe:


### PR DESCRIPTION

- Point TTS to sasquatch Kafka Broker and schema registry.
- Add a secret to kafka-producers deployment containing the ts-salkafka password to authenticate with sasquatch Kafka brokers.

I'm still missing where the command line that executes the salkafka producers is constructed. If a password is set, the command line should look like this: 

```
 ./bin/run_salkafka_producer --replication-factor 1 --broker  sasquatch-kafka-brokers.sasquatch:9092 --registry http://sasquatch-schema-registry.sasquatch:8081/  --username ts-salkafka --password <ts-salkafka-password>  <CSC list>
```
