### PR TITLE
TTS: Update csc chart and apps to handle postgres Butler.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ argocd-csc
 ##########
 
 This is the Argo CD repository for Commandable SAL Components (CSC) and related operational services.
-This deployment mechanism leverages many services provided by `SQuaRE's Rubin Science Platform deployment <https://phalanx.lsst.io>`_.
+This deployment mechanism leverages many services provided by `Phalanx: Rubin Observatory Kubernetes Application Configurations <https://phalanx.lsst.io>`_.
 
 argocd-csc is developed by the `Vera C. Rubin Observatory <https://www.lsst.org/>`_.
 

--- a/apps/atqueue/Chart.yaml
+++ b/apps/atqueue/Chart.yaml
@@ -1,4 +1,4 @@
 name: atqueue
 apiVersion: v2
-version: 0.9.2
+version: 0.10.0
 description: A Helm chart for deploying the ATScriptQueue CSC.

--- a/apps/atqueue/README.md
+++ b/apps/atqueue/README.md
@@ -8,6 +8,7 @@ A Helm chart for deploying the ATScriptQueue CSC.
 |-----|------|---------|-------------|
 | affinity | object | `{}` | This specifies the scheduling constraints of the pod |
 | annotations | object | `{}` | This allows the specification of pod annotations |
+| butlerSecret | object | `{}` | This key allows for specification of Butler secret information. If this section is used, it must contain the following attributes: _containerPath_ (The directory location for the Butler secret), _dbUser_ (The username for the Butler backend database) |
 | entrypoint | string | `nil` | This key allows specification of a script to override the entrypoint |
 | env | object | `{}` | This section holds a set of key, value pairs for environmental variables (ENV_VAR: value) |
 | envSecrets | list | `[]` | This section holds specifications for secret injection. If this section is used, each object listed must have the following attributes defined: _name_ (The label for the secret), _secretName_ (The name of the vault store reference. Uses the _namespace_ attribute to construct the full name), _secretKey_ (The key in the vault store containing the necessary secret) |

--- a/apps/atqueue/values-tucson-teststand.yaml
+++ b/apps/atqueue/values-tucson-teststand.yaml
@@ -11,6 +11,9 @@ env:
   RUN_ARG: 2 --state enabled
 shmemDir: /run/ospl
 osplVersion: V6.10.4
+butlerSecret:
+  containerPath: /home/saluser/.lsst
+  dbUser: oods
 nfsMountpoint:
 - name: auxtel-gen3-butler
   containerPath: /repo/LATISS

--- a/apps/atqueue/values.yaml
+++ b/apps/atqueue/values.yaml
@@ -17,6 +17,11 @@ env: {}
 envSecrets: []
 # -- This key allows specification of a script to override the entrypoint
 entrypoint:
+# -- This key allows for specification of Butler secret information.
+# If this section is used, it must contain the following attributes:
+# _containerPath_ (The directory location for the Butler secret),
+# _dbUser_ (The username for the Butler backend database)
+butlerSecret: {}
 # -- This section holds the information necessary to create a volume mount for the container.
 # If this section is used, each object listed can have the following attributes defined:
 # _name_ (A label identifier for the mountpoint),

--- a/apps/cluster-config/values-tucson-teststand.yaml
+++ b/apps/cluster-config/values-tucson-teststand.yaml
@@ -18,3 +18,8 @@ secrets:
     key: ts/software/ts-salkafka
     namespaces:
       - kafka-producers
+  - name: butler-secret
+    key: butler-secret
+    namespaces:
+      - maintel
+      - obssys

--- a/apps/mtaos/Chart.yaml
+++ b/apps/mtaos/Chart.yaml
@@ -1,4 +1,4 @@
 name: mtaos
 apiVersion: v2
-version: 0.9.2
+version: 0.10.0
 description: A Helm chart for deploying the MTAOS CSC.

--- a/apps/mtaos/README.md
+++ b/apps/mtaos/README.md
@@ -8,6 +8,7 @@ A Helm chart for deploying the MTAOS CSC.
 |-----|------|---------|-------------|
 | affinity | object | `{}` | This specifies the scheduling constraints of the pod |
 | annotations | object | `{}` | This allows the specification of pod annotations |
+| butlerSecret | object | `{}` | This key allows for specification of Butler secret information. If this section is used, it must contain the following attributes: _containerPath_ (The directory location for the Butler secret), _dbUser_ (The username for the Butler backend database) |
 | entrypoint | string | `nil` | This key allows specification of a script to override the entrypoint |
 | env | object | `{}` | This section holds a set of key, value pairs for environmental variables (ENV_VAR: value) |
 | envSecrets | list | `[]` | This section holds specifications for secret injection. If this section is used, each object listed must have the following attributes defined: _name_ (The label for the secret), _secretName_ (The name of the vault store reference. Uses the _namespace_ attribute to construct the full name), _secretKey_ (The key in the vault store containing the necessary secret) |

--- a/apps/mtaos/values-tucson-teststand.yaml
+++ b/apps/mtaos/values-tucson-teststand.yaml
@@ -10,6 +10,9 @@ env:
   OSPL_ERRORFILE: /tmp/ospl-error-mtaos.log
 shmemDir: /run/ospl
 osplVersion: V6.10.4
+butlerSecret:
+  containerPath: /home/saluser/.lsst
+  dbUser: oods
 nfsMountpoint:
 - name: comcam-gen3-butler
   containerPath: /repo/LSSTComCam

--- a/apps/mtaos/values.yaml
+++ b/apps/mtaos/values.yaml
@@ -17,6 +17,11 @@ env: {}
 envSecrets: []
 # -- This key allows specification of a script to override the entrypoint
 entrypoint:
+# -- This key allows for specification of Butler secret information.
+# If this section is used, it must contain the following attributes:
+# _containerPath_ (The directory location for the Butler secret),
+# _dbUser_ (The username for the Butler backend database)
+butlerSecret: {}
 # -- This section holds the information necessary to create a volume mount for the container.
 # If this section is used, each object listed can have the following attributes defined:
 # _name_ (A label identifier for the mountpoint),

--- a/apps/mtqueue/Chart.yaml
+++ b/apps/mtqueue/Chart.yaml
@@ -1,4 +1,4 @@
 name: mtqueue
 apiVersion: v2
-version: 0.9.2
+version: 0.10.0
 description: A Helm chart for deploying the MTScriptQueue CSC.

--- a/apps/mtqueue/README.md
+++ b/apps/mtqueue/README.md
@@ -8,6 +8,7 @@ A Helm chart for deploying the MTScriptQueue CSC.
 |-----|------|---------|-------------|
 | affinity | object | `{}` | This specifies the scheduling constraints of the pod |
 | annotations | object | `{}` | This allows the specification of pod annotations |
+| butlerSecret | object | `{}` | This key allows for specification of Butler secret information. If this section is used, it must contain the following attributes: _containerPath_ (The directory location for the Butler secret), _dbUser_ (The username for the Butler backend database) |
 | entrypoint | string | `nil` | This key allows specification of a script to override the entrypoint |
 | env | object | `{}` | This section holds a set of key, value pairs for environmental variables (ENV_VAR: value) |
 | envSecrets | list | `[]` | This section holds specifications for secret injection. If this section is used, each object listed must have the following attributes defined: _name_ (The label for the secret), _secretName_ (The name of the vault store reference. Uses the _namespace_ attribute to construct the full name), _secretKey_ (The key in the vault store containing the necessary secret) |

--- a/apps/mtqueue/values-tucson-teststand.yaml
+++ b/apps/mtqueue/values-tucson-teststand.yaml
@@ -11,6 +11,9 @@ env:
   RUN_ARG: 1 --state enabled
 shmemDir: /run/ospl
 osplVersion: V6.10.4
+butlerSecret:
+  containerPath: /home/saluser/.lsst
+  dbUser: oods
 nfsMountpoint:
 - name: auxtel-gen3-butler
   containerPath: /repo/LATISS

--- a/apps/mtqueue/values.yaml
+++ b/apps/mtqueue/values.yaml
@@ -17,6 +17,11 @@ env: {}
 envSecrets: []
 # -- This key allows specification of a script to override the entrypoint
 entrypoint:
+# -- This key allows for specification of Butler secret information.
+# If this section is used, it must contain the following attributes:
+# _containerPath_ (The directory location for the Butler secret),
+# _dbUser_ (The username for the Butler backend database)
+butlerSecret: {}
 # -- This section holds the information necessary to create a volume mount for the container.
 # If this section is used, each object listed can have the following attributes defined:
 # _name_ (A label identifier for the mountpoint),

--- a/charts/csc/job.yaml
+++ b/charts/csc/job.yaml
@@ -40,6 +40,12 @@ spec:
                   key: {{ $env.secretKey }}
           {{- end }}
           {{- end }}
+          {{- if .Values.butlerSecret }}
+            - name: PGPASSFILE
+              value: "{{ .Values.butlerSecret.containerPath }}/postgres-credentials.txt"
+            - name: PGUSER
+              value: {{ .Values.butlerSecret.dbUser | quote }}
+          {{- end }}
           volumeMounts:
             {{- if .Values.useExternalConfig }}
             - name: osplconfig
@@ -54,6 +60,10 @@ spec:
             - name: entrypoint
               mountPath: /home/saluser/.startup.sh
               subPath: .startup.sh
+          {{- end }}
+          {{- if .Values.butlerSecret }}
+            - name: {{ .Release.Name }}-butler-secret
+              mountPath: {{ .Values.butlerSecret.containerPath }}
           {{- end }}
           {{- if .Values.pvcMountpoint }}
           {{- range $values := .Values.pvcMountpoint }}
@@ -80,6 +90,24 @@ spec:
           securityContext:
             privileged: true
       {{- end }}
+      {{- if .Values.butlerSecret }}
+      initContainers:
+        - name: {{ .Release.Name }}-butler-secret-perm-fixer
+          image: "alpine:latest"
+          command:
+            - "/bin/ash"
+            - "-c"
+            - |
+              cp -RL /secrets-raw/* /secrets
+              chown 73006:73006 /secrets/*
+              chmod 0600 /secrets/*
+          volumeMounts:
+            - name: {{ .Release.Name }}-raw-butler-secret
+              mountPath: /secrets-raw
+              readOnly: true
+            - name: {{ .Release.Name }}-butler-secret
+              mountPath: /secrets
+      {{- end }}
       volumes:
         {{- if .Values.useExternalConfig }}
         - name: osplconfig
@@ -102,6 +130,14 @@ spec:
             items:
               - key: .startup.sh
                 path: .startup.sh
+      {{- end }}
+      {{- if .Values.butlerSecret }}
+        - name: {{ .Release.Name }}-butler-secret
+          emptyDir: {}
+        - name: {{ .Release.Name }}-raw-butler-secret
+          secret:
+            secretName: {{ $.Values.namespace }}-butler-secret
+            defaultMode: 0600
       {{- end }}
       {{- if .Values.pvcMountpoint }}
       {{- range $values := .Values.pvcMountpoint }}

--- a/docs/arch/secrets.rst
+++ b/docs/arch/secrets.rst
@@ -5,7 +5,7 @@ Secrets
 Vault
 -----
 
-The CSC deployment leverages the `Vault <https://www.hashicorp.com/products/vault>`_ system provided by SQuaRE for `Kubernetes secret management <https://phalanx.lsst.io/arch/secrets.html#vault>`_.
+The CSC deployment leverages the `Vault <https://www.hashicorp.com/products/vault>`_ system provided by SQuaRE for `Kubernetes secret management <https://phalanx.lsst.io/about/secrets.html#vault>`_.
 This deployment uses the ``ts/software`` extension to the nominal vault path for a given site.
 Each secret is maintained by its own collection key and then sub-divisions for individual secrets.
 The current keys and values will be enumerated here.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ CSC Operations with Argo CD
 
 `Argo CD`_ is the mechanism used to control the deployment configuration of some control system components to Kubernetes_.
 The description of the control system architecture is given in `LSE-150 <https://ls.st/lse-150>`_.
-The `SQuaRE RSP deployment introduction <https://phalanx.lsst.io/introduction.html>`_ has a good brief on the concepts of the deployment mechanism.
+The `Overview of the Phalanx platform concepts <https://phalanx.lsst.io/about/introduction.html>`_ has a good brief on the concepts of the deployment mechanism.
 The deployment system uses Helm_ charts to control the delivered content to Kubernetes_.
 The Helm_ charts are part of the application or linked from a shared directory if more than one application uses the same chart.
 The `Argo CD`_ configuration and this documentation are stored in the `argocd-csc <https://github.com/lsst-ts/argocd-csc>`_ repository in GitHub_.
@@ -47,6 +47,18 @@ For the Kubernetes_ systems, the appropriate ``kubeconfig`` file can be obtained
    app-maint/upgrade-application
    app-maint/add-application
    app-maint/making-changes
+
+Shared Helm Charts
+==================
+
+This section covers tracking changes to the two shared charts: ``csc`` and ``csc_collector``.
+The individual applications using these shared charts can point the ``version`` attribute in its `Chart.yaml` file independently of any other application.
+
+.. toctree::
+   :maxdepth: 2
+
+   shared-charts/csc
+   shared-charts/csc-collector
 
 Operations Guide
 ================

--- a/docs/shared-charts/csc-collector.rst
+++ b/docs/shared-charts/csc-collector.rst
@@ -1,0 +1,14 @@
+########################
+CSC-Collector Helm Chart
+########################
+
+0.2.0
+-----
+
+  This is the canonical version of the chart.
+  It contains the following functionality:
+
+  * Specifying the CSCs that belong to a given collector app
+  * Handling indexed components
+  * Allow components to be specified as simulators
+  * Allow name remapping of applications

--- a/docs/shared-charts/csc.rst
+++ b/docs/shared-charts/csc.rst
@@ -1,0 +1,45 @@
+##############
+CSC Helm Chart
+##############
+
+0.10.0
+------
+
+  This version provides for injecting Butler secrets into the application pod.
+  In order to use this version, the following needs to be added to the application `values.yaml`:
+
+  .. code::
+
+    # -- This key allows for specification of Butler secret information
+    # If this section is used, it must contain the following attribute:
+    # __containerPath__ (The directory location for the Butler secret)
+    # __dbUser__ (The username for the Butler backend database)
+    butlerSecret:
+
+  To activate the feature, the site-specific values files need to have explicit information added.
+  This is an example from the ``atqueue`` `values-tucson-teststand.yaml`:
+
+  .. code::
+
+    butlerSecret:
+      containerPath: /home/saluser/.lsst
+      dbUser: oods
+
+0.9.2
+-----
+
+  This is the canonical version of the CSC Helm chart.
+  It contains the following functionality:
+
+  * Specify the container image for the application
+  * Specify environmental variables for the application
+  * Specify secret type environmental variables for the application
+  * Provide the capability of overriding the container entrypoint
+  * Specify Persistent Volume Claims for application ephemeral storage
+  * Specify NFS mounts for application data sharing
+  * Ability to use either external or internal OSPL configuration
+  * Provide flexible location of the OSPL shmem directory
+  * Provide annotation capability for the application pod
+  * Provide mechanism for init containers for handling multus access
+  * Allow application pods to use host PID and IPC spaces
+  * Provide the capability for a Service attachment for the application


### PR DESCRIPTION
* Add new secret to cluster-config.
* Add Butler secret handling to csc chart.
* Update atqueue, mtqueue and mtaos.
* Add documentation for shared chart versions.
* Fix URLs for Phalanx documentation.