### PR TITLE
Increase body size for nginx requests to 5MB

### DIFF
--- a/apps/love-nginx/values-base-teststand.yaml
+++ b/apps/love-nginx/values-base-teststand.yaml
@@ -39,6 +39,7 @@ nginxConfig: |
       try_files $uri$args $uri$args/ $uri/ /love/index.html;
     }
     location /love/manager {
+        client_max_body_size 5M;
         proxy_pass http://love-manager-frontend-service:8000;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;

--- a/apps/love-nginx/values-summit.yaml
+++ b/apps/love-nginx/values-summit.yaml
@@ -39,6 +39,7 @@ nginxConfig: |
       try_files $uri$args $uri$args/ $uri/ /love/index.html;
     }
     location /love/manager {
+        client_max_body_size 5M;
         proxy_pass http://love-manager-frontend-service:8000;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;

--- a/apps/love-nginx/values-tucson-teststand.yaml
+++ b/apps/love-nginx/values-tucson-teststand.yaml
@@ -39,6 +39,7 @@ nginxConfig: |
       try_files $uri$args $uri$args/ $uri/ /love/index.html;
     }
     location /love/manager {
+        client_max_body_size 5M;
         proxy_pass http://love-manager-frontend-service:8000;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
This PR sets a new nginx configuration on the `nginx.conf` file in order to allow user files uploads up to 5MB.