### PR TITLE
skip_at_slew_image: Skip the auxtel-telescope-slew-take-image-daytime-checkout

### DIFF
--- a/workflows/integration-testing/templates/imaging-workflow.yaml
+++ b/workflows/integration-testing/templates/imaging-workflow.yaml
@@ -85,19 +85,19 @@ spec:
             value: "-A Test_Report_AuxTel_Telescope_Dome_Checkout.list"
           - name: jobname
             value: auxtel-telescope-dome-daytime-checkout
-      - name: auxtel-telescope-slew-take-image-daytime-checkout
-        depends: auxtel-telescope-dome-daytime-checkout
-        templateRef:
-          name: integration-test-job-template
-          template: inttest-template
-        arguments:
-          parameters:
-          - name: integrationtest
-            value: "-A Test_Report_AuxTel_Slew_and_Take_Image_Checkout.list"
-          - name: jobname
-            value: auxtel-telescope-slew-take-image-daytime-checkout
+      #- name: auxtel-telescope-slew-take-image-daytime-checkout
+        #depends: auxtel-telescope-dome-daytime-checkout
+        #templateRef:
+          #name: integration-test-job-template
+          #template: inttest-template
+        #arguments:
+          #parameters:
+          #- name: integrationtest
+          #  value: "-A Test_Report_AuxTel_Slew_and_Take_Image_Checkout.list"
+          #- name: jobname
+          #  value: auxtel-telescope-slew-take-image-daytime-checkout
       - name: auxtel-prep-flat
-        depends: auxtel-telescope-slew-take-image-daytime-checkout
+        depends: auxtel-telescope-dome-daytime-checkout #auxtel-telescope-slew-take-image-daytime-checkout
         templateRef:
           name: integration-test-job-template
           template: inttest-template


### PR DESCRIPTION
in imaging-workflow.yaml.